### PR TITLE
feat: adiciona campo endereço e torna CPF obrigatório em Professor

### DIFF
--- a/api/src/main/java/com/apae/gestao/controller/ProfessorController.java
+++ b/api/src/main/java/com/apae/gestao/controller/ProfessorController.java
@@ -20,12 +20,8 @@ public class ProfessorController {
 
     @PostMapping
     public ResponseEntity<ProfessorResponseDTO> criar(@Valid @RequestBody ProfessorRequestDTO dto) {
-        try {
-            ProfessorResponseDTO response = professorService.criar(dto);
-            return ResponseEntity.status(HttpStatus.CREATED).body(response);
-        } catch (RuntimeException e) {
-            return ResponseEntity.badRequest().build();
-        }
+        ProfessorResponseDTO response = professorService.criar(dto);
+        return ResponseEntity.status(HttpStatus.CREATED).body(response);
     }
 
     @GetMapping

--- a/api/src/main/java/com/apae/gestao/dto/ProfessorRequestDTO.java
+++ b/api/src/main/java/com/apae/gestao/dto/ProfessorRequestDTO.java
@@ -21,6 +21,8 @@ public class ProfessorRequestDTO {
     @Size(max = 100, message = "Nome deve ter no máximo 100 caracteres")
     private String nome;
 
+    @NotBlank(message = "CPF é obrigatório")
+    @Size(min = 11, max = 14 , message = "CPF deve ter entre 11 e 14 caracteres")
     private String cpf;
 
     @NotBlank(message = "Email é obrigatório")
@@ -37,6 +39,9 @@ public class ProfessorRequestDTO {
     private String especialidade;
 
     private LocalDate dataContratacao;
+
+    @Size(max = 255, message = "Endereço deve ter no máximo 255 caracteres")
+    private String endereco;
 
     private Set<Turma> turmas;
 }

--- a/api/src/main/java/com/apae/gestao/dto/ProfessorResponseDTO.java
+++ b/api/src/main/java/com/apae/gestao/dto/ProfessorResponseDTO.java
@@ -24,6 +24,7 @@ public class ProfessorResponseDTO {
     private LocalDate dataNascimento;
     private String especialidade;
     private LocalDate dataContratacao;
+    private String endereco;
     private Boolean ativo;
     private LocalDateTime createdAt;
     private LocalDateTime updatedAt;
@@ -38,6 +39,7 @@ public class ProfessorResponseDTO {
         this.dataNascimento = professor.getDataNascimento();
         this.especialidade = professor.getEspecialidade();
         this.dataContratacao = professor.getDataContratacao();
+        this.endereco = professor.getEndereco();
         this.ativo = professor.getAtivo();
         this.createdAt = professor.getCreatedAt();
         this.updatedAt = professor.getUpdatedAt();

--- a/api/src/main/java/com/apae/gestao/entity/Professor.java
+++ b/api/src/main/java/com/apae/gestao/entity/Professor.java
@@ -29,7 +29,7 @@ public class Professor {
     @Column(nullable = false, length = 100)
     private String nome;
 
-    @Column(nullable = true, unique = true, length = 14)
+    @Column(nullable = false, unique = true, length = 14)
     private String cpf;
 
     @Column(nullable = true, unique = true, length = 100)
@@ -46,6 +46,9 @@ public class Professor {
 
     @Column(name = "data_contratacao")
     private LocalDate dataContratacao;
+
+    @Column(length = 255)
+    private String endereco;
 
     @Column(nullable = false)
     private Boolean ativo = true;

--- a/api/src/main/java/com/apae/gestao/service/ProfessorService.java
+++ b/api/src/main/java/com/apae/gestao/service/ProfessorService.java
@@ -99,12 +99,10 @@ public class ProfessorService {
         professor.setDataNascimento(dto.getDataNascimento());
         professor.setEspecialidade(dto.getEspecialidade());
         professor.setDataContratacao(dto.getDataContratacao());
+        professor.setEndereco(dto.getEndereco());
     }
 
     private void validarCpfUnico(String cpf, Long id) {
-        if (cpf == null || cpf.isBlank()) {
-            return; // CPF opcional: não validar quando ausente
-        }
         if (id == null) {
             if (professorRepository.existsByCpf(cpf)) {
                 throw new RuntimeException("CPF já cadastrado: " + cpf);


### PR DESCRIPTION
# O que mudou?

Adicionado campo de endereço na entidade Professor e tornado o campo CPF obrigatório para garantir a integridade dos dados cadastrados.

## Tarefas Relacionadas

* Issue: https://github.com/IFPBEsp/APAE-gestao-escolar/issues/63
* Outras dependências: {pr_link}

## Mudanças Realizadas

* Adicionado campo `endereco` na entidade `Professor`
* Alterado campo `cpf` para obrigatório na entidade `Professor`
* Atualizado `ProfessorRequestDTO`:
  - Adicionado campo `endereco` com validação de tamanho máximo (255 caracteres)
  - Adicionado `@NotBlank` no campo `cpf` para torná-lo obrigatório
  - Adicionado validação de tamanho para CPF (11-14 caracteres)
* Atualizado `ProfessorResponseDTO` para incluir campo `endereco`
* Atualizado método `mapearDtoParaEntity` no `ProfessorService` para mapear o campo `endereco`
* Removida validação opcional de CPF no método `validarCpfUnico` (agora sempre valida)

## Evidências

###Teste de criação com endereço e CPF obrigatório:
<img width="1488" height="843" alt="Captura de tela 2025-11-08 211413" src="https://github.com/user-attachments/assets/546c7018-b964-4dfa-b497-47eacf23477e" />

###Teste de validação - CPF ausente:
<img width="1489" height="720" alt="Captura de tela 2025-11-08 211309" src="https://github.com/user-attachments/assets/b25ca92e-38bc-4b6b-9d24-9416b77930b4" />

### Teste de validação - CPF duplicado:
<img width="1489" height="654" alt="Captura de tela 2025-11-08 212600" src="https://github.com/user-attachments/assets/c98eb502-8fab-4220-b4b5-394d49d6c477" />

