### PR TITLE
refactor: implementa tratamento centralizado de exceções em Turma

### DIFF
--- a/api/src/main/java/com/apae/gestao/controller/TurmaController.java
+++ b/api/src/main/java/com/apae/gestao/controller/TurmaController.java
@@ -22,22 +22,14 @@ public class TurmaController {
 
     @PostMapping
     public ResponseEntity<TurmaResponseDTO> criar(@Valid @RequestBody TurmaRequestDTO dto){
-        try {
-            TurmaResponseDTO response = service.criar(dto);
-            return ResponseEntity.status(HttpStatus.CREATED).body(response);
-        } catch (RuntimeException e) {
-            return ResponseEntity.badRequest().build();
-        }
+        TurmaResponseDTO response = service.criar(dto);
+        return ResponseEntity.status(HttpStatus.CREATED).body(response);
     }
 
     @GetMapping("/{turmaId}")
     public ResponseEntity<TurmaResponseDTO> listarPorId(@PathVariable long turmaId){
-        try {
-            TurmaResponseDTO response = service.buscarPorId(turmaId);
-            return ResponseEntity.ok(response);
-        } catch (RuntimeException e) {
-            return ResponseEntity.notFound().build();
-        }
+        TurmaResponseDTO response = service.buscarPorId(turmaId);
+        return ResponseEntity.ok(response);
     }
 
     @GetMapping
@@ -48,22 +40,14 @@ public class TurmaController {
 
     @PutMapping("/{turmaId}")
     public ResponseEntity<TurmaResponseDTO> atualizar(@PathVariable Long turmaId, @Valid @RequestBody TurmaRequestDTO dto){
-        try {
-            TurmaResponseDTO response = service.atualizar(turmaId, dto);
-            return ResponseEntity.ok(response);
-        } catch (RuntimeException e) {
-            return ResponseEntity.badRequest().build();
-        }
+        TurmaResponseDTO response = service.atualizar(turmaId, dto);
+        return ResponseEntity.ok(response);
     }
 
     @DeleteMapping("/{id}")
     public ResponseEntity<TurmaResponseDTO> deletar(@PathVariable Long id){
-        try {
-            service.buscarPorId(id);
-            return ResponseEntity.noContent().build();
-        } catch (RuntimeException e) {
-            return ResponseEntity.notFound().build();
-        }
+        service.deletarPorId(id);
+        return ResponseEntity.noContent().build();
     }
 
     @PostMapping("/{turmaId}/professores")
@@ -71,22 +55,14 @@ public class TurmaController {
         @PathVariable Long turmaId,
         @RequestBody List<Long> idProfessores
     ){
-        try {
-            TurmaResponseDTO atualizado = service.vincularProfessoresATurma(turmaId, idProfessores);
-            return ResponseEntity.ok(atualizado);
-        } catch (Exception e) {
-            return ResponseEntity.badRequest().build();
-        }
+        TurmaResponseDTO atualizado = service.vincularProfessoresATurma(turmaId, idProfessores);
+        return ResponseEntity.ok(atualizado);
     }
 
     @GetMapping("/{turmaId}/professores")
     public ResponseEntity<List<ProfessorResponseDTO>> listarProfessoresNaTurma(@PathVariable Long turmaId){
-        try {
-            List<ProfessorResponseDTO> response = service.listarProfessoresNaTurma(turmaId);
-            return ResponseEntity.ok(response);
-        } catch (RuntimeException e) {
-            return ResponseEntity.notFound().build();
-        }
+        List<ProfessorResponseDTO> response = service.listarProfessoresNaTurma(turmaId);
+        return ResponseEntity.ok(response);
     }
 
     @DeleteMapping("/{turmaId}/professores/{professorId}")
@@ -94,11 +70,7 @@ public class TurmaController {
         @PathVariable Long turmaId,
         @PathVariable Long professorId
     ){
-        try {
-            TurmaResponseDTO atualizado = service.desvincularProfessor(turmaId, professorId);
-            return ResponseEntity.ok(atualizado);
-        } catch (Exception e) {
-            return ResponseEntity.badRequest().build();
-        }
+        TurmaResponseDTO atualizado = service.desvincularProfessor(turmaId, professorId);
+        return ResponseEntity.ok(atualizado);
     }
 }

--- a/api/src/main/java/com/apae/gestao/service/TurmaService.java
+++ b/api/src/main/java/com/apae/gestao/service/TurmaService.java
@@ -58,7 +58,7 @@ public class TurmaService {
     @Transactional
     public void deletarPorId(Long turmaId){
         Turma turma = turmaDAO.findById(turmaId)
-            .orElseThrow(() -> new IllegalArgumentException("Turma não encontrada com ID: " + turmaId));
+                .orElseThrow(() -> new RuntimeException("Turma não encontrada com ID: " + turmaId));
         turmaDAO.delete(turma);
     }
 


### PR DESCRIPTION
# O que mudou?
Refatoração do tratamento de exceções em Turma para utilizar o GlobalExceptionHandler de forma centralizada, melhorando a consistência das respostas de erro da API.

## Tarefas Relacionadas

* Issue: https://github.com/IFPBEsp/APAE-gestao-escolar/issues/79
* Outras dependências: {pr_link}

## Mudanças Realizadas

* Removidos todos os blocos `try-catch` do `TurmaController` para permitir que exceções sejam capturadas pelo `GlobalExceptionHandler`
* Padronizada exception no método `deletarPorId` do `TurmaService`:
  - Alterado de `IllegalArgumentException` para `RuntimeException` 
  - Mantém consistência com os demais métodos do service
* Controller agora retorna respostas de erro com body contendo:
  - Timestamp do erro
  - Status HTTP
  - Mensagem descritiva do erro
* Simplificação do código do controller, removendo lógica de tratamento de erro duplicada

## Evidências

### Teste de erro - Buscar turma inexistente:
<img width="849" height="520" alt="Captura de tela 2025-11-09 185903" src="https://github.com/user-attachments/assets/e596900a-6c02-4802-82d9-95642fff69fc" />
