### PR TITLE
[Refactor] Implementação filtro por nome no endpoint de listagem de alunos

### DIFF
--- a/api/src/main/java/com/apae/gestao/controller/AlunoController.java
+++ b/api/src/main/java/com/apae/gestao/controller/AlunoController.java
@@ -19,6 +19,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -33,22 +34,21 @@ public class AlunoController {
     }
 
     @GetMapping
-    @Operation(summary = "Listar alunos", description = "Retorna todos os alunos cadastrados.")
-    public List<AlunoResponseDTO> listarTodos() {
-        return alunoService.listarTodos();
+    @Operation(summary = "Listar alunos", description = "Retorna todos os alunos cadastrados. Permite filtrar por nome.")
+    public List<AlunoResponseDTO> listarTodos(
+            @Parameter(description = "Nome do aluno para filtro", required = false) @RequestParam(required = false) String nome) {
+        return alunoService.listarTodos(nome);
     }
 
     @GetMapping("/{id}")
     @Operation(summary = "Buscar aluno por ID")
     @ApiResponses({
-        @ApiResponse(responseCode = "200", description = "Aluno encontrado", content = @Content(schema = @Schema(implementation = AlunoResponseDTO.class))),
-        @ApiResponse(responseCode = "404", description = "Aluno não encontrado", content = @Content(schema = @Schema(implementation = ApiErrorResponse.class)))
+            @ApiResponse(responseCode = "200", description = "Aluno encontrado", content = @Content(schema = @Schema(implementation = AlunoResponseDTO.class))),
+            @ApiResponse(responseCode = "404", description = "Aluno não encontrado", content = @Content(schema = @Schema(implementation = ApiErrorResponse.class)))
     })
     public ResponseEntity<AlunoResponseDTO> buscarPorId(
-            @Parameter(description = "Identificador do aluno", example = "4", in = ParameterIn.PATH)
-            @PathVariable Long id) {
+            @Parameter(description = "Identificador do aluno", example = "4", in = ParameterIn.PATH) @PathVariable Long id) {
         AlunoResponseDTO aluno = alunoService.buscarPorId(id);
         return ResponseEntity.ok(aluno);
     }
 }
-

--- a/api/src/main/java/com/apae/gestao/repository/AlunoRepository.java
+++ b/api/src/main/java/com/apae/gestao/repository/AlunoRepository.java
@@ -1,9 +1,11 @@
 package com.apae.gestao.repository;
 
+import java.util.List;
 import com.apae.gestao.entity.Aluno;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface AlunoRepository extends JpaRepository<Aluno, Long> {
+    List<Aluno> findByNomeContainingIgnoreCase(String nome);
 }

--- a/api/src/main/java/com/apae/gestao/service/AlunoService.java
+++ b/api/src/main/java/com/apae/gestao/service/AlunoService.java
@@ -21,9 +21,14 @@ public class AlunoService {
     }
 
     @Transactional(readOnly = true)
-    public List<AlunoResponseDTO> listarTodos() {
-        return alunoRepository.findAll()
-                .stream()
+    public List<AlunoResponseDTO> listarTodos(String nome) {
+        List<Aluno> alunos;
+        if (nome != null && !nome.trim().isEmpty()) {
+            alunos = alunoRepository.findByNomeContainingIgnoreCase(nome);
+        } else {
+            alunos = alunoRepository.findAll();
+        }
+        return alunos.stream()
                 .map(AlunoResponseDTO::new)
                 .collect(Collectors.toList());
     }


### PR DESCRIPTION

# O que mudou?

Implementei a funcionalidade de **filtragem de alunos por nome** no endpoint de listagem da API.

Anteriormente, o endpoint `GET /api/alunos` retornava a totalidade da base de dados de alunos de forma incondicional. Isso inviabilizava a experiência do usuário na tela de "Gerenciar Alunos", onde existe uma barra de pesquisa que requer filtragem dinâmica dos resultados.

Com esta alteração, a API passa a suportar consultas parametrizadas, permitindo que o frontend solicite apenas os registros que correspondam aos critérios de busca textual, otimizando a resposta e atendendo aos requisitos de usabilidade do sistema.

## Tarefas Relacionadas

* Issue: #122 
* Outras dependências: {pr_link}

## Mudanças Realizadas

* **Controller ([AlunoController](cci:2://file:///c:/Users/perei/APAE-gestao-escolar/api/src/main/java/com/apae/gestao/controller/AlunoController.java:24:0-53:1))**:
    * Evolução do método [listarTodos](cci:1://file:///c:/Users/perei/APAE-gestao-escolar/api/src/main/java/com/apae/gestao/controller/AlunoController.java:35:4-40:5) para aceitar um parâmetro opcional `@RequestParam(required = false) String nome`.
    * Integração com a camada de serviço para repassar o critério de filtro quando presente.

* **Repository ([AlunoRepository](cci:2://file:///c:/Users/perei/APAE-gestao-escolar/api/src/main/java/com/apae/gestao/repository/AlunoRepository.java:7:0-10:1))**:
    * Implementação do método [findByNomeContainingIgnoreCase](cci:1://file:///c:/Users/perei/APAE-gestao-escolar/api/src/main/java/com/apae/gestao/repository/AlunoRepository.java:9:4-9:60) utilizando *Spring Data JPA Query Methods*.
    * Isso garante buscas parciais (substrings) e insensíveis a maiúsculas/minúsculas (case-insensitive), proporcionando uma busca mais flexível e resiliente a erros de digitação do usuário.

* **Service ([AlunoService](cci:2://file:///c:/Users/perei/APAE-gestao-escolar/api/src/main/java/com/apae/gestao/service/AlunoService.java:13:0-49:1))**:
    * Refatoração da lógica de listagem para incluir uma verificação condicional.
    * Se o parâmetro `nome` for fornecido e não estiver vazio, o serviço invoca a busca filtrada; caso contrário, mantém o comportamento padrão de retornar todos os registros (`findAll`), garantindo retrocompatibilidade com chamadas que não utilizam o filtro.


## Evidências
<img width="1218" height="485" alt="Captura de tela 2025-12-02 194642" src="https://github.com/user-attachments/assets/b14c991e-6efd-4cbb-98bb-ed02b5ef37d0" />
<img width="1234" height="425" alt="Captura de tela 2025-12-02 194603" src="https://github.com/user-attachments/assets/60b3b6fa-b370-4062-9d46-dc134a4e5f02" />
<img width="1235" height="377" alt="Captura de tela 2025-12-02 194425" src="https://github.com/user-attachments/assets/e7c1ede4-37f6-446b-8d0d-1b21bf74eb20" />
<img width="1236" height="378" alt="Captura de tela 2025-12-02 194342" src="https://github.com/user-attachments/assets/e1e188a6-b859-472d-b80c-2b4108e7f989" />
<img width="1212" height="456" alt="Captura de tela 2025-12-02 194248" src="https://github.com/user-attachments/assets/ea94a73a-7caa-4601-8560-746525e396fa" />
<img width="1243" height="473" alt="Captura de tela 2025-12-02 191726" src="https://github.com/user-attachments/assets/0ab04a27-ad58-4c6f-bf11-05ad64fd496b" />
<img width="1240" height="479" alt="Captura de tela 2025-12-02 191651" src="https://github.com/user-attachments/assets/88f24eea-f190-40bf-9628-8ce39ed30c5a" />
<img width="1284" height="620" alt="Captura de tela 2025-12-02 191529" src="https://github.com/user-attachments/assets/58c13332-91ba-4313-bcb6-8f24aecad8a1" />
<img width="992" height="555" alt="Captura de tela 2025-12-02 191507" src="https://github.com/user-attachments/assets/84203f1e-d357-476e-b931-73e34f05e08a" />
