### PR TITLE
refactor: padronizar documentação swagger e respostas de erro

### DIFF
--- a/README.md
+++ b/README.md
@@ -277,3 +277,51 @@ git push origin feature/nova-funcionalidade
 - `style:` - Formatação de código
 - `refactor:` - Refatoração
 - `test:` - Testes
+
+## 📚 Padrão de Documentação de Endpoints (Swagger/OpenAPI)
+
+- **Anotações customizadas para erros**
+  - `@Doc400ValidationError`: adiciona `ApiResponse(400)` com `ApiErrorResponse` para erros de validação de request body.
+  - `@Doc404NotFound`: adiciona `ApiResponse(404)` com `ApiErrorResponse` para recursos não encontrados.
+  - `@DocStandardErrors`: atalho que combina `@Doc400ValidationError` + `@Doc404NotFound` para endpoints que recebem corpo válido **e** operam sobre um recurso por ID.
+  - Todas essas anotações estão no pacote `com.apae.gestao.openapi`.
+
+- **Quando usar cada anotação**
+  - **POST/PUT/PATCH com `@Valid @RequestBody` (criação/atualização)**:
+    - Use `@Doc400ValidationError` quando o endpoint **não** opera diretamente por ID (ex.: `POST /api/turmas`).
+    - Use `@DocStandardErrors` quando o endpoint recebe corpo válido **e** usa `@PathVariable` para um recurso principal (ex.: `PUT /api/professores/{id}` ou `PATCH /api/alunos/{alunoId}/turma`).
+  - **GET /{id} ou endpoints que dependem de um ID de recurso**:
+    - Use `@Doc404NotFound` junto com `@Operation` e as respostas de sucesso (ex.: `GET /api/professores/{id}`, `GET /api/alunos/{id}`, `GET /api/turmas/{id}`).
+
+- **Padrão para `summary` e `description`**
+  - **`summary`**:
+    - Sempre curto, iniciando por verbo no infinitivo: `Criar turma`, `Listar professores`, `Buscar aluno por ID`, `Atualizar professor`, `Inativar aluno na turma`.
+    - Deve deixar claro o **tipo de ação principal** (criar, listar, buscar, atualizar, inativar, ativar, vincular, etc.).
+  - **`description`**:
+    - Explica rapidamente o objetivo de negócio e detalhes relevantes, por exemplo:
+      - `"Cria uma nova turma vinculando professor e alunos por ID."`
+      - `"Desativa a turma anterior e ativa a nova turma."`
+      - `"Lista apenas os alunos com vínculo ativo na turma."`
+
+- **Exemplo de método de Controller após a refatoração**
+
+```java
+@PostMapping
+@Operation(
+        summary = "Criar turma",
+        description = "Cria uma nova turma vinculando professor e alunos por ID."
+)
+@ApiResponses({
+        @ApiResponse(responseCode = "201", description = "Turma criada",
+                content = @Content(schema = @Schema(implementation = TurmaResponseDTO.class)))
+})
+@Doc400ValidationError
+public ResponseEntity<TurmaResponseDTO> criar(@Valid @RequestBody TurmaRequestDTO dto) {
+    TurmaResponseDTO response = service.criar(dto);
+    return ResponseEntity.status(HttpStatus.CREATED).body(response);
+}
+```
+
+Neste exemplo:
+- **A documentação de sucesso (201)** continua declarada no próprio método (mais específica do caso de uso).
+- **Os erros padrão (400)** são aplicados pela anotação `@Doc400ValidationError`, evitando repetir o mesmo bloco `ApiResponse` em todos os endpoints de criação/atualização com `@Valid`.

--- a/api/src/main/java/com/apae/gestao/config/OpenApiConfig.java
+++ b/api/src/main/java/com/apae/gestao/config/OpenApiConfig.java
@@ -1,7 +1,6 @@
 package com.apae.gestao.config;
 
 
-import org.springdoc.core.models.GroupedOpenApi;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -73,46 +72,5 @@ public class OpenApiConfig {
                         .type(io.swagger.v3.oas.models.security.SecurityScheme.Type.HTTP)
                         .scheme("bearer")
                         .bearerFormat("JWT"));
-    }
-
-    @Bean
-    public GroupedOpenApi professorApi() {
-        return GroupedOpenApi.builder()
-                .group("Professores")
-                .pathsToMatch("/api/professores/**")
-                .build();
-    }
-
-    @Bean
-    public GroupedOpenApi turmaApi() {
-        return GroupedOpenApi.builder()
-                .group("Turmas")
-                .pathsToMatch("/api/turmas/**")
-                .build();
-    }
-
-    @Bean
-    public GroupedOpenApi alunoApi() {
-        return GroupedOpenApi.builder()
-                .group("Alunos")
-                .pathsToMatch("/api/alunos/**")
-                .build();
-    }
-    
-    
-    @Bean
-    public GroupedOpenApi relatorioApi() {
-        return GroupedOpenApi.builder()
-                .group("Relatórios")
-                .pathsToMatch("/api/relatorios/**")
-                .build();
-    }
-
-    @Bean
-    public GroupedOpenApi avaliacaoApi() {
-        return GroupedOpenApi.builder()
-                .group("Avaliações")
-                .pathsToMatch("/api/avaliacoes/**")
-                .build();
     }
 }

--- a/api/src/main/java/com/apae/gestao/config/SecurityConfig.java
+++ b/api/src/main/java/com/apae/gestao/config/SecurityConfig.java
@@ -29,7 +29,14 @@ public class SecurityConfig {
                         session.sessionCreationPolicy(SessionCreationPolicy.STATELESS)
                 )
                 .authorizeHttpRequests(auth -> auth
-                        .requestMatchers("/api/auth/login", "/api/auth/primeiro-acesso").permitAll()
+                        .requestMatchers(
+                                "/api/auth/login",
+                                "/api/auth/primeiro-acesso",
+                                "/v3/api-docs/**",
+                                "/swagger-ui/**",
+                                "/swagger-ui.html",
+                                "/docs/**"
+                        ).permitAll()
                         .requestMatchers("/api/admin/**").hasRole("ADMIN")
                         .requestMatchers("/api/professor/**").hasRole("TEACHER")
                         .anyRequest().authenticated()

--- a/api/src/main/java/com/apae/gestao/controller/AlunoController.java
+++ b/api/src/main/java/com/apae/gestao/controller/AlunoController.java
@@ -105,9 +105,9 @@ public class AlunoController {
         description = "Retorna todas as turmas em que o aluno possui ou possuiu vínculo (ativas ou inativas, vínculo atual ou antigo)."
     )
     @ApiResponses({
-            @ApiResponse(responseCode = "200", description = "Lista retornada com sucesso"),
-            @ApiResponse(responseCode = "404", description = "Aluno não encontrado")
+            @ApiResponse(responseCode = "200", description = "Lista retornada com sucesso")
     })
+    @Doc404NotFound
     public ResponseEntity<List<AlunoTurmaHistoricoItemDTO>> listarHistoricoTurmasPorAlunoId(
             @PathVariable Long id
     ) {

--- a/api/src/main/java/com/apae/gestao/controller/AlunoController.java
+++ b/api/src/main/java/com/apae/gestao/controller/AlunoController.java
@@ -5,6 +5,9 @@ import com.apae.gestao.dto.AvaliacaoHistoricoResponseDTO;
 import com.apae.gestao.dto.aluno.AlunoDetalhesDTO;
 import com.apae.gestao.dto.aluno.AlunoResumoDTO;
 import com.apae.gestao.service.AlunoService;
+import com.apae.gestao.openapi.Doc400ValidationError;
+import com.apae.gestao.openapi.Doc404NotFound;
+import com.apae.gestao.openapi.DocStandardErrors;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -55,9 +58,9 @@ public class AlunoController {
     @GetMapping("/{id}")
     @Operation(summary = "Buscar aluno por ID")
     @ApiResponses({
-            @ApiResponse(responseCode = "200", description = "Aluno encontrado"),
-            @ApiResponse(responseCode = "404", description = "Aluno não encontrado")
+            @ApiResponse(responseCode = "200", description = "Aluno encontrado")
     })
+    @Doc404NotFound
     public ResponseEntity<AlunoDetalhesDTO> buscarPorId(@PathVariable Long id) {
         AlunoDetalhesDTO aluno = alunoService.buscarPorId(id);
         return ResponseEntity.ok(aluno);
@@ -69,10 +72,9 @@ public class AlunoController {
         description = "Desativa a turma anterior e ativa a nova turma."
     )
     @ApiResponses({
-        @ApiResponse(responseCode = "200", description = "Turma atualizada com sucesso"),
-        @ApiResponse(responseCode = "404", description = "Aluno ou Turma não encontrados"),
-        @ApiResponse(responseCode = "400", description = "Requisição inválida")
+        @ApiResponse(responseCode = "200", description = "Turma atualizada com sucesso")
     })
+    @DocStandardErrors
     public ResponseEntity<AlunoDetalhesDTO> atualizarTurma(
         @PathVariable Long alunoId,
         @Valid @RequestBody AlunoTurmaRequestDTO dto
@@ -85,6 +87,7 @@ public class AlunoController {
 
     @GetMapping("/{id}/avaliacoes")
     @Operation(summary = "Buscar histórico de avaliações do aluno")
+    @Doc404NotFound
     public ResponseEntity<List<AvaliacaoHistoricoResponseDTO>> buscarAvaliacoesPorAlunoId(
             @PathVariable Long id
     ) {

--- a/api/src/main/java/com/apae/gestao/controller/AvaliacaoController.java
+++ b/api/src/main/java/com/apae/gestao/controller/AvaliacaoController.java
@@ -2,8 +2,10 @@ package com.apae.gestao.controller;
 
 import com.apae.gestao.dto.AvaliacaoRequestDTO;
 import com.apae.gestao.dto.AvaliacaoResponseDTO;
-import com.apae.gestao.dto.ApiErrorResponse;
 import com.apae.gestao.service.AvaliacaoService;
+import com.apae.gestao.openapi.Doc400ValidationError;
+import com.apae.gestao.openapi.Doc404NotFound;
+import com.apae.gestao.openapi.DocStandardErrors;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 
@@ -33,9 +35,9 @@ public class AvaliacaoController {
     @PostMapping
     @Operation(summary = "Criar uma nova avaliação")
     @ApiResponses({
-            @ApiResponse(responseCode = "201", description = "Avaliação criada com sucesso", content = @Content(schema = @Schema(implementation = AvaliacaoResponseDTO.class))),
-            @ApiResponse(responseCode = "400", description = "Dados de entrada inválidos", content = @Content(schema = @Schema(implementation = ApiErrorResponse.class)))
+            @ApiResponse(responseCode = "201", description = "Avaliação criada com sucesso", content = @Content(schema = @Schema(implementation = AvaliacaoResponseDTO.class)))
     })
+    @Doc400ValidationError
     public ResponseEntity<AvaliacaoResponseDTO> criar(@Valid @RequestBody AvaliacaoRequestDTO dto) {
         AvaliacaoResponseDTO response = avaliacaoService.criar(dto);
         return ResponseEntity.status(HttpStatus.CREATED).body(response);
@@ -51,9 +53,9 @@ public class AvaliacaoController {
     @GetMapping("/{id}")
     @Operation(summary = "Buscar avaliação por ID")
     @ApiResponses({
-            @ApiResponse(responseCode = "200", description = "Avaliação encontrada", content = @Content(schema = @Schema(implementation = AvaliacaoResponseDTO.class))),
-            @ApiResponse(responseCode = "404", description = "Avaliação não encontrada", content = @Content(schema = @Schema(implementation = ApiErrorResponse.class)))
+            @ApiResponse(responseCode = "200", description = "Avaliação encontrada", content = @Content(schema = @Schema(implementation = AvaliacaoResponseDTO.class)))
     })
+    @Doc404NotFound
     public ResponseEntity<AvaliacaoResponseDTO> buscarPorId(
             @Parameter(description = "Identificador da avaliação", example = "1", in = ParameterIn.PATH) @PathVariable Long id) {
         AvaliacaoResponseDTO response = avaliacaoService.buscarPorId(id);
@@ -63,6 +65,7 @@ public class AvaliacaoController {
 
     @GetMapping("/alunos/{alunoId}")
     @Operation(summary = "Listar avaliações por aluno")
+    @Doc404NotFound
     public ResponseEntity<List<AvaliacaoResponseDTO>> listarPorAluno(
             @Parameter(description = "ID do aluno", example = "5", in = ParameterIn.PATH) @PathVariable Long alunoId) {
         List<AvaliacaoResponseDTO> response = avaliacaoService.listarPorAluno(alunoId);
@@ -71,6 +74,7 @@ public class AvaliacaoController {
 
     @GetMapping("/professores/{professorId}")
     @Operation(summary = "Listar avaliações por professor")
+    @Doc404NotFound
     public ResponseEntity<List<AvaliacaoResponseDTO>> listarPorProfessor(
             @Parameter(description = "ID do professor", example = "2", in = ParameterIn.PATH) @PathVariable Long professorId) {
         List<AvaliacaoResponseDTO> response = avaliacaoService.listarPorProfessor(professorId);
@@ -80,9 +84,9 @@ public class AvaliacaoController {
     @PutMapping("/{id}")
     @Operation(summary = "Atualizar uma avaliação")
     @ApiResponses({
-            @ApiResponse(responseCode = "200", description = "Avaliação atualizada", content = @Content(schema = @Schema(implementation = AvaliacaoResponseDTO.class))),
-            @ApiResponse(responseCode = "404", description = "Avaliação não encontrada", content = @Content(schema = @Schema(implementation = ApiErrorResponse.class)))
+            @ApiResponse(responseCode = "200", description = "Avaliação atualizada", content = @Content(schema = @Schema(implementation = AvaliacaoResponseDTO.class)))
     })
+    @DocStandardErrors
     public ResponseEntity<AvaliacaoResponseDTO> atualizar(
             @Parameter(description = "Identificador da avaliação", example = "1", in = ParameterIn.PATH) @PathVariable Long id,
             @Valid @RequestBody AvaliacaoRequestDTO dto) {
@@ -93,9 +97,9 @@ public class AvaliacaoController {
     @DeleteMapping("/{id}")
     @Operation(summary = "Deletar uma avaliação")
     @ApiResponses({
-            @ApiResponse(responseCode = "204", description = "Avaliação deletada"),
-            @ApiResponse(responseCode = "404", description = "Avaliação não encontrada", content = @Content(schema = @Schema(implementation = ApiErrorResponse.class)))
+            @ApiResponse(responseCode = "204", description = "Avaliação deletada")
     })
+    @Doc404NotFound
     public ResponseEntity<Void> deletar(
             @Parameter(description = "Identificador da avaliação", example = "1", in = ParameterIn.PATH) @PathVariable Long id) {
         avaliacaoService.deletar(id);

--- a/api/src/main/java/com/apae/gestao/controller/FrequenciaController.java
+++ b/api/src/main/java/com/apae/gestao/controller/FrequenciaController.java
@@ -11,27 +11,32 @@ import com.apae.gestao.dto.aluno.AlunoFrequenciaResumoDTO;
 import com.apae.gestao.dto.aula.AulaPresencaAlunoResponseDTO;
 import com.apae.gestao.dto.turma.TurmaResumoFrequenciaDTO;
 import com.apae.gestao.service.FrequenciaService;
+import com.apae.gestao.openapi.Doc404NotFound;
 
+import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 
 @RestController
 @RequestMapping("/api/frequencia")
-@Tag(name = "Frequências")
+@Tag(name = "Frequências", description = "Consulta de frequência e histórico de presença.")
 @RequiredArgsConstructor
 @SecurityRequirement(name = "bearerAuth")
 public class FrequenciaController {
 
-    
     private final FrequenciaService frequenciaService;
 
     @GetMapping("/turma/{id}/resumo")
+    @Operation(summary = "Resumo de frequência da turma", description = "Retorna o resumo de frequência de uma turma específica.")
+    @Doc404NotFound
     public TurmaResumoFrequenciaDTO getResumoTurma(@PathVariable Long id) {
         return frequenciaService.getResumoTurma(id);
     }
 
     @GetMapping("/turma/{id}/alunos")
+    @Operation(summary = "Listar alunos com frequência da turma", description = "Lista os alunos de uma turma com seus dados de frequência.")
+    @Doc404NotFound
     public Page<AlunoFrequenciaResumoDTO> listarAlunos(
         @PathVariable Long id,
         Pageable pageable
@@ -40,6 +45,8 @@ public class FrequenciaController {
     }
 
     @GetMapping("/aluno/{id}/historico")
+    @Operation(summary = "Histórico individual de presença do aluno", description = "Retorna o histórico detalhado de presença de um aluno específico.")
+    @Doc404NotFound
     public Page<AulaPresencaAlunoResponseDTO> getHistoricoIndividualAluno(
         @PathVariable Long id,
         Pageable pageable

--- a/api/src/main/java/com/apae/gestao/controller/PresencaController.java
+++ b/api/src/main/java/com/apae/gestao/controller/PresencaController.java
@@ -3,6 +3,13 @@ package com.apae.gestao.controller;
 import com.apae.gestao.dto.ChamadaResponseDTO;
 import com.apae.gestao.dto.RegistrarChamadaRequestDTO;
 import com.apae.gestao.service.PresencaService;
+import com.apae.gestao.openapi.Doc400ValidationError;
+import com.apae.gestao.openapi.Doc404NotFound;
+import com.apae.gestao.openapi.DocStandardErrors;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.format.annotation.DateTimeFormat;
@@ -13,12 +20,16 @@ import java.time.LocalDate;
 
 @RestController
 @RequestMapping("/api/presencas")
+@Tag(name = "Presenças", description = "Gerenciamento de chamadas e presenças dos alunos.")
+@SecurityRequirement(name = "bearerAuth")
 @RequiredArgsConstructor
 public class PresencaController {
 
     private final PresencaService presencaService;
 
     @GetMapping("/chamadas/turmas/{turmaId}")
+    @Operation(summary = "Buscar chamada por turma e data", description = "Retorna a chamada de uma turma em uma data específica.")
+    @Doc404NotFound
     public ResponseEntity<ChamadaResponseDTO> getChamadaPorTurmaEData(
             @PathVariable Long turmaId,
             @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate data) {
@@ -28,6 +39,8 @@ public class PresencaController {
     }
 
     @PostMapping("/chamadas/turmas/{turmaId}")
+    @Operation(summary = "Registrar chamada", description = "Registra a chamada de presença para uma turma em uma data específica.")
+    @DocStandardErrors
     public ResponseEntity<ChamadaResponseDTO> registrarChamada(
             @PathVariable Long turmaId,
             @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate data,
@@ -38,6 +51,8 @@ public class PresencaController {
     }
 
     @DeleteMapping("/{id}")
+    @Operation(summary = "Deletar presença", description = "Remove um registro de presença pelo ID.")
+    @Doc404NotFound
     public ResponseEntity<Void> deletar(@PathVariable Long id) {
         presencaService.deletar(id);
         return ResponseEntity.noContent().build();

--- a/api/src/main/java/com/apae/gestao/controller/ProfessorController.java
+++ b/api/src/main/java/com/apae/gestao/controller/ProfessorController.java
@@ -4,6 +4,9 @@ import java.util.List;
 import com.apae.gestao.dto.*;
 import com.apae.gestao.dto.turma.TurmaResponseDTO;
 import com.apae.gestao.service.ProfessorService;
+import com.apae.gestao.openapi.Doc400ValidationError;
+import com.apae.gestao.openapi.Doc404NotFound;
+import com.apae.gestao.openapi.DocStandardErrors;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.enums.ParameterIn;
@@ -60,9 +63,9 @@ public class ProfessorController {
     )
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "Professor encontrado",
-                    content = @Content(schema = @Schema(implementation = ProfessorResumoDTO.class))),
-            @ApiResponse(responseCode = "404", description = "Professor não encontrado")
+                    content = @Content(schema = @Schema(implementation = ProfessorResumoDTO.class)))
     })
+    @Doc404NotFound
     public ResponseEntity<ProfessorResumoDTO> buscarPorId(
             @Parameter(description = "Identificador do professor", example = "10", in = ParameterIn.PATH)
             @PathVariable Long id) {
@@ -77,9 +80,9 @@ public class ProfessorController {
     )
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "Professor encontrado",
-                    content = @Content(schema = @Schema(implementation = ProfessorResponseDTO.class))),
-            @ApiResponse(responseCode = "404", description = "Professor não encontrado")
+                    content = @Content(schema = @Schema(implementation = ProfessorResponseDTO.class)))
     })
+    @Doc404NotFound
     public ResponseEntity<ProfessorResponseDTO> buscarPorIdCompleto(
             @Parameter(description = "Identificador do professor", example = "10", in = ParameterIn.QUERY)
             @RequestParam("id") Long id) {
@@ -93,9 +96,9 @@ public class ProfessorController {
             description = "Registra um novo professor."
     )
     @ApiResponses({
-            @ApiResponse(responseCode = "201", description = "Professor criado com sucesso"),
-            @ApiResponse(responseCode = "400", description = "Dados inválidos")
+            @ApiResponse(responseCode = "201", description = "Professor criado com sucesso")
     })
+    @Doc400ValidationError
     public ResponseEntity<ProfessorResponseDTO> criar(@Valid @RequestBody ProfessorRequestDTO dto) {
         ProfessorResponseDTO response = professorService.criar(dto);
         return ResponseEntity.status(HttpStatus.CREATED).body(response);
@@ -103,6 +106,7 @@ public class ProfessorController {
 
     @PutMapping("/{id}")
     @Operation(summary = "Atualizar professor existente")
+    @DocStandardErrors
     public ResponseEntity<ProfessorResponseDTO> atualizar(
             @Parameter(description = "Identificador do professor", example = "10", in = ParameterIn.PATH)
             @PathVariable Long id,
@@ -113,6 +117,7 @@ public class ProfessorController {
 
     @PatchMapping("/{id}/inativar")
     @Operation(summary = "Inativar professor")
+    @Doc404NotFound
     public ResponseEntity<ProfessorResponseDTO> inativar(
             @Parameter(description = "Identificador do professor", example = "10", in = ParameterIn.PATH)
             @PathVariable Long id) {
@@ -122,6 +127,7 @@ public class ProfessorController {
 
     @PatchMapping("/{id}/ativar")
     @Operation(summary = "Reativar professor")
+    @Doc404NotFound
     public ResponseEntity<ProfessorResponseDTO> reativar(
             @Parameter(description = "Identificador do professor", example = "10", in = ParameterIn.PATH)
             @PathVariable Long id) {
@@ -131,6 +137,7 @@ public class ProfessorController {
 
     @GetMapping("/{id}/turmas")
     @Operation(summary = "Listar turmas de um professor")
+    @Doc404NotFound
     public ResponseEntity<List<TurmaResumoDTO>> getTurmasDeProfessor(
             @Parameter(description = "Identificador do professor", example = "10", in = ParameterIn.PATH)
             @PathVariable Long id) {

--- a/api/src/main/java/com/apae/gestao/controller/RelatorioController.java
+++ b/api/src/main/java/com/apae/gestao/controller/RelatorioController.java
@@ -2,10 +2,11 @@ package com.apae.gestao.controller;
 
 import java.util.List;
 
-import com.apae.gestao.dto.ApiErrorResponse;
 import com.apae.gestao.dto.RelatorioRequestDTO;
 import com.apae.gestao.dto.RelatorioResponseDTO;
 import com.apae.gestao.service.RelatorioService;
+import com.apae.gestao.openapi.Doc400ValidationError;
+import com.apae.gestao.openapi.Doc404NotFound;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -33,9 +34,9 @@ public class RelatorioController {
     @PostMapping
     @Operation(summary = "Criar um novo relatório")
     @ApiResponses({
-            @ApiResponse(responseCode = "200", description = "Relatório criado", content = @Content(schema = @Schema(implementation = RelatorioResponseDTO.class))),
-            @ApiResponse(responseCode = "400", description = "Dados inválidos", content = @Content(schema = @Schema(implementation = ApiErrorResponse.class)))
+            @ApiResponse(responseCode = "200", description = "Relatório criado", content = @Content(schema = @Schema(implementation = RelatorioResponseDTO.class)))
     })
+    @Doc400ValidationError
     public ResponseEntity<RelatorioResponseDTO> criar(@RequestBody RelatorioRequestDTO request) {
         RelatorioResponseDTO relatorio = relatorioService.criar(request);
         return ResponseEntity.ok(relatorio);
@@ -51,9 +52,9 @@ public class RelatorioController {
     @GetMapping("/{id}")
     @Operation(summary = "Buscar relatório por ID")
     @ApiResponses({
-            @ApiResponse(responseCode = "200", description = "Relatório encontrado", content = @Content(schema = @Schema(implementation = RelatorioResponseDTO.class))),
-            @ApiResponse(responseCode = "404", description = "Relatório não encontrado", content = @Content(schema = @Schema(implementation = ApiErrorResponse.class)))
+            @ApiResponse(responseCode = "200", description = "Relatório encontrado", content = @Content(schema = @Schema(implementation = RelatorioResponseDTO.class)))
     })
+    @Doc404NotFound
     public ResponseEntity<RelatorioResponseDTO> buscarPorId(
             @Parameter(description = "Identificador do relatório", example = "1", in = ParameterIn.PATH) @PathVariable Long id) {
         RelatorioResponseDTO relatorio = relatorioService.buscarPorId(id);
@@ -62,6 +63,7 @@ public class RelatorioController {
 
     @GetMapping("/alunos/{alunoId}")
     @Operation(summary = "Listar relatórios de um aluno específico")
+    @Doc404NotFound
     public ResponseEntity<List<RelatorioResponseDTO>> listarPorAluno(@PathVariable Long alunoId) {
         List<RelatorioResponseDTO> relatorios = relatorioService.buscarPorAluno(alunoId);
         return ResponseEntity.ok(relatorios);
@@ -70,9 +72,9 @@ public class RelatorioController {
     @PutMapping("/{id}")
     @Operation(summary = "Atualizar um relatório")
     @ApiResponses({
-            @ApiResponse(responseCode = "200", description = "Relatório atualizado", content = @Content(schema = @Schema(implementation = RelatorioResponseDTO.class))),
-            @ApiResponse(responseCode = "404", description = "Relatório não encontrado", content = @Content(schema = @Schema(implementation = ApiErrorResponse.class)))
+            @ApiResponse(responseCode = "200", description = "Relatório atualizado", content = @Content(schema = @Schema(implementation = RelatorioResponseDTO.class)))
     })
+    @Doc404NotFound
     public ResponseEntity<RelatorioResponseDTO> atualizar(
             @Parameter(description = "Identificador do relatório", example = "1", in = ParameterIn.PATH) @PathVariable Long id,
             @RequestBody RelatorioRequestDTO request) {
@@ -83,9 +85,9 @@ public class RelatorioController {
     @DeleteMapping("/{id}")
     @Operation(summary = "Deletar um relatório")
     @ApiResponses({
-            @ApiResponse(responseCode = "204", description = "Relatório deletado"),
-            @ApiResponse(responseCode = "404", description = "Relatório não encontrado", content = @Content(schema = @Schema(implementation = ApiErrorResponse.class)))
+            @ApiResponse(responseCode = "204", description = "Relatório deletado")
     })
+    @Doc404NotFound
     public ResponseEntity<Void> deletar(
             @Parameter(description = "Identificador do relatório", example = "1", in = ParameterIn.PATH) @PathVariable Long id) {
         relatorioService.deletar(id);

--- a/api/src/main/java/com/apae/gestao/controller/RelatorioController.java
+++ b/api/src/main/java/com/apae/gestao/controller/RelatorioController.java
@@ -7,6 +7,7 @@ import com.apae.gestao.dto.RelatorioResponseDTO;
 import com.apae.gestao.service.RelatorioService;
 import com.apae.gestao.openapi.Doc400ValidationError;
 import com.apae.gestao.openapi.Doc404NotFound;
+import com.apae.gestao.openapi.DocStandardErrors;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -36,7 +37,7 @@ public class RelatorioController {
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "Relatório criado", content = @Content(schema = @Schema(implementation = RelatorioResponseDTO.class)))
     })
-    @Doc400ValidationError
+    @DocStandardErrors
     public ResponseEntity<RelatorioResponseDTO> criar(@RequestBody RelatorioRequestDTO request) {
         RelatorioResponseDTO relatorio = relatorioService.criar(request);
         return ResponseEntity.ok(relatorio);
@@ -74,7 +75,7 @@ public class RelatorioController {
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "Relatório atualizado", content = @Content(schema = @Schema(implementation = RelatorioResponseDTO.class)))
     })
-    @Doc404NotFound
+    @DocStandardErrors
     public ResponseEntity<RelatorioResponseDTO> atualizar(
             @Parameter(description = "Identificador do relatório", example = "1", in = ParameterIn.PATH) @PathVariable Long id,
             @RequestBody RelatorioRequestDTO request) {

--- a/api/src/main/java/com/apae/gestao/controller/RelatorioController.java
+++ b/api/src/main/java/com/apae/gestao/controller/RelatorioController.java
@@ -37,7 +37,7 @@ public class RelatorioController {
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "Relatório criado", content = @Content(schema = @Schema(implementation = RelatorioResponseDTO.class)))
     })
-    @DocStandardErrors
+    @Doc400ValidationError
     public ResponseEntity<RelatorioResponseDTO> criar(@RequestBody RelatorioRequestDTO request) {
         RelatorioResponseDTO relatorio = relatorioService.criar(request);
         return ResponseEntity.ok(relatorio);

--- a/api/src/main/java/com/apae/gestao/controller/TurmaController.java
+++ b/api/src/main/java/com/apae/gestao/controller/TurmaController.java
@@ -183,6 +183,7 @@ public class TurmaController {
             summary = "Adicionar alunos à turma",
             description = "Adiciona uma lista de alunos já cadastrados a uma turma existente."
     )
+    @Doc404NotFound
     public ResponseEntity<TurmaResponseDTO> adicionarAlunos(@RequestBody List<Long> alunosId, @PathVariable Long turmaId){
         TurmaResponseDTO response = service.adicionarAlunos(turmaId, alunosId);
         return ResponseEntity.ok(response);
@@ -193,6 +194,7 @@ public class TurmaController {
             summary = "Listar alunos da turma",
             description = "Lista todos os alunos, ativos e inativos, vinculados à turma."
     )
+    @Doc404NotFound
     public ResponseEntity<List<TurmaAlunoResponseDTO>> listarAlunosNaTurma(@PathVariable Long turmaId){
         List<TurmaAlunoResponseDTO> response = service.listarAlunos(turmaId);
         return ResponseEntity.ok(response);
@@ -203,6 +205,7 @@ public class TurmaController {
             summary = "Listar alunos ativos da turma",
             description = "Lista apenas os alunos com vínculo ativo na turma."
     )
+    @Doc404NotFound
     public ResponseEntity<List<TurmaAlunoResponseDTO>> listarAlunosAtivosNaTurma(@PathVariable Long turmaId){
         List<TurmaAlunoResponseDTO> response = service.listarAlunosAtivos(turmaId);
         return ResponseEntity.ok(response);
@@ -213,6 +216,7 @@ public class TurmaController {
             summary = "Listar alunos inativos da turma",
             description = "Lista apenas os alunos com vínculo inativo na turma."
     )
+    @Doc404NotFound
     public ResponseEntity<List<TurmaAlunoResponseDTO>> listarAlunosInativosNaTurma(@PathVariable Long turmaId){
         List<TurmaAlunoResponseDTO> response = service.listarAlunosInativos(turmaId);
         return ResponseEntity.ok(response);
@@ -223,6 +227,7 @@ public class TurmaController {
             summary = "Ativar aluno na turma",
             description = "Reativa o vínculo do aluno com a turma para participação nas atividades."
     )
+    @Doc404NotFound
     public ResponseEntity<TurmaAlunoResponseDTO> ativarAlunoNaTurma(@PathVariable Long turmaId, @PathVariable Long alunoId){
         service.ativarAluno(turmaId, alunoId);
         return ResponseEntity.ok().build();
@@ -233,6 +238,7 @@ public class TurmaController {
             summary = "Inativar aluno na turma",
             description = "Inativa o vínculo do aluno com a turma, mantendo o histórico preservado."
     )
+    @Doc404NotFound
     public ResponseEntity<TurmaAlunoResponseDTO> desativarAlunoNaTurma(@PathVariable Long turmaId, @PathVariable Long alunoId){
         service.desativarAluno(turmaId, alunoId);
         return ResponseEntity.ok().build();

--- a/api/src/main/java/com/apae/gestao/controller/TurmaController.java
+++ b/api/src/main/java/com/apae/gestao/controller/TurmaController.java
@@ -183,7 +183,7 @@ public class TurmaController {
             summary = "Adicionar alunos à turma",
             description = "Adiciona uma lista de alunos já cadastrados a uma turma existente."
     )
-    @Doc404NotFound
+    @DocStandardErrors
     public ResponseEntity<TurmaResponseDTO> adicionarAlunos(@RequestBody List<Long> alunosId, @PathVariable Long turmaId){
         TurmaResponseDTO response = service.adicionarAlunos(turmaId, alunosId);
         return ResponseEntity.ok(response);

--- a/api/src/main/java/com/apae/gestao/controller/TurmaController.java
+++ b/api/src/main/java/com/apae/gestao/controller/TurmaController.java
@@ -12,6 +12,9 @@ import com.apae.gestao.dto.turma.TurmaRequestDTO;
 import com.apae.gestao.dto.turma.TurmaResponseDTO;
 import com.apae.gestao.dto.turmaAluno.TurmaAlunoResponseDTO;
 import com.apae.gestao.service.TurmaService;
+import com.apae.gestao.openapi.Doc400ValidationError;
+import com.apae.gestao.openapi.Doc404NotFound;
+import com.apae.gestao.openapi.DocStandardErrors;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -52,10 +55,9 @@ public class TurmaController {
                           "professor": { "id": 2, "nome": "Maria da Silva" },
                           "alunosIds": [1, 2, 3]
                         }
-                        """))),
-            @ApiResponse(responseCode = "400", description = "Dados inválidos", content = @Content(
-                    schema = @Schema(implementation = ApiErrorResponse.class)))
+                        """)))
     })
+    @Doc400ValidationError
     public ResponseEntity<TurmaResponseDTO> criar(@Valid @RequestBody TurmaRequestDTO dto){
         TurmaResponseDTO response = service.criar(dto);
         return ResponseEntity.status(HttpStatus.CREATED).body(response);
@@ -68,9 +70,9 @@ public class TurmaController {
     )
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "Turma encontrada",
-                    content = @Content(schema = @Schema(implementation = TurmaResumoDTO.class))),
-            @ApiResponse(responseCode = "404", description = "Turma não encontrada")
+                    content = @Content(schema = @Schema(implementation = TurmaResumoDTO.class)))
     })
+    @Doc404NotFound
     public ResponseEntity<TurmaResumoDTO> buscarPorId(
             @Parameter(description = "Identificador da turma", example = "7", in = ParameterIn.PATH)
             @PathVariable Long id) {
@@ -120,6 +122,11 @@ public class TurmaController {
 
     @PutMapping("/{turmaId}")
     @Operation(summary = "Atualizar turma existente")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Turma atualizada com sucesso",
+                    content = @Content(schema = @Schema(implementation = TurmaResponseDTO.class)))
+    })
+    @DocStandardErrors
     public ResponseEntity<TurmaResponseDTO> atualizar(
             @Parameter(description = "Identificador da turma", example = "5", in = ParameterIn.PATH)
             @PathVariable Long turmaId,
@@ -130,6 +137,7 @@ public class TurmaController {
 
     @DeleteMapping("/{id}")
     @Operation(summary = "Excluir turma definitivamente")
+    @Doc404NotFound
     public ResponseEntity<Void> deletar(
             @Parameter(description = "Identificador da turma", example = "5", in = ParameterIn.PATH)
             @PathVariable Long id){
@@ -139,6 +147,7 @@ public class TurmaController {
 
     @PutMapping("/{turmaId}/professor/{professorId}")
     @Operation(summary = "Vincular professor a uma turma específica")
+    @Doc404NotFound
     public ResponseEntity<TurmaResponseDTO> atribuirProfessor(
             @Parameter(description = "Identificador da turma", example = "5", in = ParameterIn.PATH)
             @PathVariable Long turmaId,
@@ -151,6 +160,7 @@ public class TurmaController {
 
     @PatchMapping("/{turmaId}/ativar")
     @Operation(summary = "Ativar turma")
+    @Doc404NotFound
     public ResponseEntity<TurmaResponseDTO> ativarTurma(
             @Parameter(description = "Identificador da turma", example = "5", in = ParameterIn.PATH)
             @PathVariable Long turmaId) {
@@ -160,6 +170,7 @@ public class TurmaController {
 
     @PatchMapping("/{turmaId}/desativar")
     @Operation(summary = "Desativar turma")
+    @Doc404NotFound
     public ResponseEntity<TurmaResponseDTO> desativarTurma(
             @Parameter(description = "Identificador da turma", example = "5", in = ParameterIn.PATH)
             @PathVariable Long turmaId) {
@@ -168,36 +179,60 @@ public class TurmaController {
     }
 
     @PostMapping("/{turmaId}/alunos")
+    @Operation(
+            summary = "Adicionar alunos à turma",
+            description = "Adiciona uma lista de alunos já cadastrados a uma turma existente."
+    )
     public ResponseEntity<TurmaResponseDTO> adicionarAlunos(@RequestBody List<Long> alunosId, @PathVariable Long turmaId){
         TurmaResponseDTO response = service.adicionarAlunos(turmaId, alunosId);
         return ResponseEntity.ok(response);
     }
 
     @GetMapping("/{turmaId}/alunos")
+    @Operation(
+            summary = "Listar alunos da turma",
+            description = "Lista todos os alunos, ativos e inativos, vinculados à turma."
+    )
     public ResponseEntity<List<TurmaAlunoResponseDTO>> listarAlunosNaTurma(@PathVariable Long turmaId){
         List<TurmaAlunoResponseDTO> response = service.listarAlunos(turmaId);
         return ResponseEntity.ok(response);
     }
 
     @GetMapping("/{turmaId}/alunos/ativos")
+    @Operation(
+            summary = "Listar alunos ativos da turma",
+            description = "Lista apenas os alunos com vínculo ativo na turma."
+    )
     public ResponseEntity<List<TurmaAlunoResponseDTO>> listarAlunosAtivosNaTurma(@PathVariable Long turmaId){
         List<TurmaAlunoResponseDTO> response = service.listarAlunosAtivos(turmaId);
         return ResponseEntity.ok(response);
     }
 
     @GetMapping("/{turmaId}/alunos/inativos")
+    @Operation(
+            summary = "Listar alunos inativos da turma",
+            description = "Lista apenas os alunos com vínculo inativo na turma."
+    )
     public ResponseEntity<List<TurmaAlunoResponseDTO>> listarAlunosInativosNaTurma(@PathVariable Long turmaId){
         List<TurmaAlunoResponseDTO> response = service.listarAlunosInativos(turmaId);
         return ResponseEntity.ok(response);
     }
 
     @PatchMapping("/{turmaId}/alunos/{alunoId}/ativar")
+    @Operation(
+            summary = "Ativar aluno na turma",
+            description = "Reativa o vínculo do aluno com a turma para participação nas atividades."
+    )
     public ResponseEntity<TurmaAlunoResponseDTO> ativarAlunoNaTurma(@PathVariable Long turmaId, @PathVariable Long alunoId){
         service.ativarAluno(alunoId, turmaId);
         return ResponseEntity.ok().build();
     }
 
     @PatchMapping("/{turmaId}/alunos/{alunoId}/inativar")
+    @Operation(
+            summary = "Inativar aluno na turma",
+            description = "Inativa o vínculo do aluno com a turma, mantendo o histórico preservado."
+    )
     public ResponseEntity<TurmaAlunoResponseDTO> desativarAlunoNaTurma(@PathVariable Long turmaId, @PathVariable Long alunoId){
         service.desativarAluno(alunoId, turmaId);
         return ResponseEntity.ok().build();

--- a/api/src/main/java/com/apae/gestao/openapi/Doc400ValidationError.java
+++ b/api/src/main/java/com/apae/gestao/openapi/Doc400ValidationError.java
@@ -1,0 +1,26 @@
+package com.apae.gestao.openapi;
+
+import com.apae.gestao.dto.ApiErrorResponse;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Resposta padronizada de erro 400 (dados inválidos) usando ApiErrorResponse.
+ * Pode ser aplicada diretamente em métodos ou usada como meta-anotação.
+ */
+@Target({ElementType.METHOD, ElementType.ANNOTATION_TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@ApiResponse(
+        responseCode = "400",
+        description = "Dados inválidos",
+        content = @Content(schema = @Schema(implementation = ApiErrorResponse.class))
+)
+public @interface Doc400ValidationError {
+}
+

--- a/api/src/main/java/com/apae/gestao/openapi/Doc404NotFound.java
+++ b/api/src/main/java/com/apae/gestao/openapi/Doc404NotFound.java
@@ -1,0 +1,26 @@
+package com.apae.gestao.openapi;
+
+import com.apae.gestao.dto.ApiErrorResponse;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Resposta padronizada de erro 404 (recurso não encontrado) usando ApiErrorResponse.
+ * Pode ser aplicada diretamente em métodos ou usada como meta-anotação.
+ */
+@Target({ElementType.METHOD, ElementType.ANNOTATION_TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@ApiResponse(
+        responseCode = "404",
+        description = "Recurso não encontrado",
+        content = @Content(schema = @Schema(implementation = ApiErrorResponse.class))
+)
+public @interface Doc404NotFound {
+}
+

--- a/api/src/main/java/com/apae/gestao/openapi/DocStandardErrors.java
+++ b/api/src/main/java/com/apae/gestao/openapi/DocStandardErrors.java
@@ -1,0 +1,18 @@
+package com.apae.gestao.openapi;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Combinação padrão de erros 400 (validação) e 404 (recurso não encontrado).
+ * Útil para endpoints que recebem corpo válido e operam sobre um recurso por ID.
+ */
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+@Doc400ValidationError
+@Doc404NotFound
+public @interface DocStandardErrors {
+}
+

--- a/api/src/main/resources/application.properties
+++ b/api/src/main/resources/application.properties
@@ -33,7 +33,10 @@ springdoc.swagger-ui.default-model-expand-depth=1
 springdoc.swagger-ui.defaultModelsExpandDepth=0
 springdoc.swagger-ui.persistAuthorization=true
 springdoc.swagger-ui.syntaxHighlight.theme=monokai
-springdoc.swagger-ui.customcssurl=/swagger-ui/swagger-custom.css
+# CSS customizado inline para esconder o seletor "Select a definition" do topo
+springdoc.swagger-ui.customCss=.swagger-ui .topbar .download-url-wrapper,.swagger-ui .topbar .select-label,.swagger-ui .topbar select{display:none !important;}
+# Caso queira usar um arquivo físico em vez de customCss, descomente a linha abaixo e garanta que o recurso exista nesse path.
+# springdoc.swagger-ui.customcssurl=/swagger-ui/swagger-custom.css
 springdoc.swagger-ui.customfavicon=https://apaebrasil.org.br/wp-content/uploads/2021/01/cropped-apae-icon-32x32.png
 springdoc.swagger-ui.logo.url=https://apaebrasil.org.br/wp-content/uploads/2021/01/logo-apae-2.png
 springdoc.default-produces-media-type=application/json

--- a/api/src/main/resources/static/swagger-ui/swagger-custom.css
+++ b/api/src/main/resources/static/swagger-ui/swagger-custom.css
@@ -33,3 +33,10 @@
   color: #fff;
 }
 
+/* Esconde o seletor de definição de grupos no topo ("Select a definition") */
+.swagger-ui .topbar .download-url-wrapper,
+.swagger-ui .topbar .select-label,
+.swagger-ui .topbar select {
+  display: none !important;
+}
+


### PR DESCRIPTION
# O que mudou?
Este PR implementa a padronização e limpeza da documentação Swagger/OpenAPI da API APAE Gestão Escolar conforme a issue: remoção do seletor "Select a definition", coerência nos endpoints de Turmas, padronização das respostas 400/404 com ApiErrorResponse, centralização das anotações OpenAPI em anotações customizadas e documentação do padrão no README.
**"Select a definition"**: A issue pedia ocultar o seletor "Select a definition" no topo do Swagger UI. Primeiro tentei via CSS (swagger-custom.css e depois springdoc.swagger-ui.customCss), mas o arquivo customizado retornava 404 e o CSS inline não era aplicado de forma confiável na UI. A solução que funcionou foi remover os beans GroupedOpenApi em OpenApiConfig. Com vários grupos (Alunos, Turmas, Professores, etc.), o Swagger UI exibe o dropdown; com um único documento OpenAPI (sem grupos), o dropdown deixa de ser renderizado. A organização por seções continua via @Tag nos controllers.

## Tarefas Relacionadas

* Issue:  https://github.com/orgs/IFPBEsp/projects/14/views/1?pane=issue&itemId=142476272&issue=IFPBEsp%7CAPAE-gestao-escolar%7C125

## Mudanças Realizadas

* Remoção do seletor "Select a definition" ao eliminar os GroupedOpenApi em OpenApiConfig; documentação exibida em um único documento, organizado por tags.
* Inclusão de @Operation (summary/description) em todos os endpoints de turmas (incluindo alunos na turma, ativar/inativar), garantindo listagem completa e ordem lógica no Swagger.
* Criação das anotações @Doc400ValidationError, @Doc404NotFound e @DocStandardErrors no pacote openapi, usando ApiErrorResponse; aplicação em AlunoController, ProfessorController e TurmaController nos endpoints com @Valid @RequestBody e/ou operação por ID.
* Substituição de blocos repetitivos de @ApiResponses pelas anotações customizadas, reduzindo ruído nos métodos.
* Nova seção "Padrão de Documentação de Endpoints (Swagger/OpenAPI)" com orientação de uso das anotações, padrão de summary/description e exemplo de método após refatoração.

## Evidências
<img width="1796" height="852" alt="Captura de tela de 2026-03-13 18-10-35" src="https://github.com/user-attachments/assets/6881c164-bc3e-425b-a12c-e08f35f07fb3" />

<img width="1535" height="436" alt="Captura de tela de 2026-03-13 18-18-34" src="https://github.com/user-attachments/assets/a2158eee-6800-4a5e-af89-75bf068b8336" />

<img width="1565" height="721" alt="Captura de tela de 2026-03-13 18-18-14" src="https://github.com/user-attachments/assets/ce08b6d1-a5ce-454f-97be-5cbf2bb189a6" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Standardized, reusable annotations for consistent 400/404 API documentation.

* **Documentation**
  * Expanded README with examples and API-docs conventions.
  * Enriched endpoint summaries/descriptions across multiple controllers.
  * Updated Swagger/OpenAPI docs usage via new annotations.

* **Refactor**
  * Simplified API documentation grouping to a single group.

* **Chores**
  * Made API docs and Swagger UI endpoints publicly reachable; adjusted Swagger UI styling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->