### PR TITLE
feat(turmas): nome unico na criacao com sufixo (2), (3)... se duplicado

### DIFF
--- a/api/src/main/java/com/apae/gestao/repository/TurmaRepository.java
+++ b/api/src/main/java/com/apae/gestao/repository/TurmaRepository.java
@@ -13,6 +13,8 @@ import java.util.Optional;
 @Repository
 public interface TurmaRepository extends JpaRepository<Turma, Long> {
 
+    boolean existsByNome(String nome);
+
     @Query("""
         SELECT new com.apae.gestao.dto.turma.TurmaResumoFrequenciaDTO(
             CAST(SUM(CASE WHEN p.faltou = false THEN 1.0 ELSE 0.0 END) * 100.0 / NULLIF(COUNT(p), 0) AS double),

--- a/api/src/main/java/com/apae/gestao/service/TurmaService.java
+++ b/api/src/main/java/com/apae/gestao/service/TurmaService.java
@@ -87,8 +87,26 @@ public class TurmaService {
     public TurmaResponseDTO criar(TurmaRequestDTO dto) {
         Turma turma = new Turma();
         mapearDtoParaEntity(dto, turma);
+        turma.setNome(obterNomeUnicoParaTurma(turma.getNome()));
         Turma salvo = turmaDAO.save(turma);
         return new TurmaResponseDTO(salvo);
+    }
+
+    /**
+     * Garante um nome único para a turma. Se já existir turma com o mesmo nome,
+     * adiciona sufixo numérico (2), (3), ... até encontrar um nome disponível.
+     */
+    private String obterNomeUnicoParaTurma(String nomeBase) {
+        if (!turmaDAO.existsByNome(nomeBase)) {
+            return nomeBase;
+        }
+        int sufixo = 2;
+        String nomeCandidato;
+        do {
+            nomeCandidato = nomeBase + " (" + sufixo + ")";
+            sufixo++;
+        } while (turmaDAO.existsByNome(nomeCandidato));
+        return nomeCandidato;
     }
 
     @Transactional(readOnly = true)


### PR DESCRIPTION
# O que mudou?

Este PR implementa a verificação de duplicidade de nome na criação de turmas. Antes, era possível criar várias turmas com o mesmo nome (derivado de tipo + ano + turno), o que gerava confusão na identificação. Agora, se já existir uma turma com aquele nome, o sistema passa a atribuir automaticamente um sufixo numérico **(2), (3), (4)** e assim por diante, garantindo nome único no sistema.

## Tarefas Relacionadas

* Issue: https://github.com/orgs/IFPBEsp/projects/14/views/1?pane=issue&itemId=165299668&issue=IFPBEsp%7CAPAE-gestao-escolar%7C252

## Mudanças Realizadas

* Adicionado método `existsByNome(String nome)` em `TurmaRepository` para consultar se já existe turma com determinado nome.
* No método `criar` de `TurmaService`, após montar a entidade a partir do DTO, o nome passou a ser ajustado por um método auxiliar que garante unicidade.
* Implementado método privado `obterNomeUnicoParaTurma(String nomeBase)` em `TurmaService`: retorna o nome base se estiver livre; caso contrário, tenta sufixos "(2)", "(3)", etc. até encontrar um nome não utilizado.

## Evidências

<img width="1259" height="712" alt="image" src="https://github.com/user-attachments/assets/4e8e77b2-a9b0-4211-8abb-ddf0585ce5b9" />

<img width="352" height="291" alt="image" src="https://github.com/user-attachments/assets/a875cd5e-a90c-4e74-9b61-5afb77c51f53" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Class names are now automatically made unique. If a name already exists, the system appends a number to prevent naming conflicts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->