### PR TITLE
[REFACTOR] Padronizar botões de detalhes de professor e turma no celular

### DIFF
--- a/app/src/app/admin/professores/[id]/page.tsx
+++ b/app/src/app/admin/professores/[id]/page.tsx
@@ -312,11 +312,11 @@ export default function DetalhesProfessor() {
               </div>
 
               {/* Botões de Ação */}
-              <div className="mt-8 flex flex-col gap-3 border-t border-[#E2E8F0] pt-6 md:flex-row">
+              <div className="mt-8 pt-6 border-t border-[#E2E8F0] flex flex-col md:flex-row gap-4 w-full">
                 <Button
                   variant="primary"
                   onClick={() => setIsModalEditarOpen(true)}
-                  className="w-full flex-1"
+                  className="w-full md:flex-1"
                 >
                   <Edit className="mr-2 h-5 w-5" />
                   Editar Professor
@@ -325,7 +325,7 @@ export default function DetalhesProfessor() {
                 <Button
                   variant={professor.ativo ? "danger" : "primary"}
                   onClick={() => setIsAlertOpen(true)}
-                  className={`w-full flex-1 ${!professor.ativo ? activateButtonStyles : ""}`}
+                  className={`w-full md:flex-1 ${!professor.ativo ? activateButtonStyles : ""}`}
                 >
                   <Power className="mr-2 h-5 w-5" />
                   {professor.ativo ? "Inativar Professor" : "Ativar Professor"}


### PR DESCRIPTION
# O que mudou?

Padronizei o estilo dos botões indicados (Ações como: Editar e Ativar/Inativar) na visualização mobile da página Detalhes do Professor para que fiquem idênticos aos aplicados na página de Detalhes da Turma.


## Tarefas Relacionadas

* Issue: {issue_link} #276 
* Outras dependências: {pr_link}

## Mudanças Realizadas

* O container dos botões foi reestruturado de: className="mt-8 flex flex-col gap-3 border-t border-[#E2E8F0] pt-6 md:flex-row"
Para adotar a mesma proporção e comportamento do container da turma: className="mt-8 pt-6 border-t border-[#E2E8F0] flex flex-col md:flex-row gap-4 w-full"
* As classes individuais dos botões Button presentes nesse container foram de: className="w-full flex-1"
* Para a seguinte estrutura correta que garante uma altura/largura fluída até a quebra nos dispositivos não-móveis, semelhante aos da Turma: className="w-full md:flex-1"

## Evidências

<img width="887" height="963" alt="Captura de tela 2026-03-17 210430" src="https://github.com/user-attachments/assets/6162d54c-d1ec-4c0f-bcb2-ebe262b29862" />
<img width="1368" height="921" alt="Captura de tela 2026-03-17 211320" src="https://github.com/user-attachments/assets/0a627ce8-165f-4607-801c-da14d433629e" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved action buttons layout with enhanced responsive spacing and sizing adjustments for better display across desktop and mobile devices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->