### PR TITLE
[REFACTOR] Definir automaticamente o ano atual na criação de novas turmas

### DIFF
--- a/app/src/components/turmas/NovaTurmaModal.tsx
+++ b/app/src/components/turmas/NovaTurmaModal.tsx
@@ -180,7 +180,7 @@ export function NovaTurmaModal({ isOpen, onClose, onSave }: NovaTurmaModalProps)
 
     function resetForm() {
         setTipo("");
-        setAno("2025");
+        setAno(new Date().getFullYear().toString());
         setTurno("");
         setBuscaProfessor("");
         setProfessorSelecionado(null);
@@ -230,7 +230,7 @@ export function NovaTurmaModal({ isOpen, onClose, onSave }: NovaTurmaModalProps)
                             <Input
                                 value={ano}
                                 onChange={(e) => setAno(e.target.value)}
-                                placeholder="Digite o ano (ex: 2025)"
+                                placeholder="Digite o ano (ex: 2026)"
                                 className="bg-white border-[#B2D7EC]"
                             />
                         </div>


### PR DESCRIPTION
Close #259 

# O que mudou?

Agora o ano das turmas é denifido automaticamente ao criar uma nova turma, tirando a necessidade de mudar toda vez ao criar.

## Tarefas Relacionadas

* Issue: https://github.com/IFPBEsp/APAE-gestao-escolar/issues/259
* Outras dependências: {pr_link}

## Mudanças Realizadas

* Mudança no state de ano em NovaTurmaModal para passar o ano atual

## Evidências

build:
<img width="1356" height="712" alt="build259" src="https://github.com/user-attachments/assets/7573171e-4ed9-497f-8c5e-3c10f6129c13" />

antes:
<img width="1393" height="793" alt="antes" src="https://github.com/user-attachments/assets/56f9e753-2ba1-4a61-8bbc-d8870a4db60e" />


depois:
<img width="1396" height="793" alt="depois" src="https://github.com/user-attachments/assets/fe33a0a4-782d-4a65-9e13-467fd9d50691" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * The "year" field in the new class modal now defaults to the current year instead of a fixed value.
  * Form reset now restores the year to the current year.
  * Updated the year input placeholder example to a more recent year.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->