### PR TITLE
[REFACTOR] Padronizar tamanho de fontes entre telas de avaliações e relatórios do aluno

### DIFF
--- a/app/src/app/professor/alunos/[alunoId]/relatorios/page.tsx
+++ b/app/src/app/professor/alunos/[alunoId]/relatorios/page.tsx
@@ -211,7 +211,7 @@ export default function RelatoriosAlunoListaPage() {
                 </div>
 
                 {/* Lista de Relatórios */}
-                <div className="divide-y-2 divide-[#B2D7EC]">
+                <div className="w-full">
                   {relatorios.length === 0 ? (
                     <div className="p-8 text-center text-gray-500">
                       Nenhum relatório encontrado.


### PR DESCRIPTION
Close #272 

# O que mudou?

Agora a tela de relatórios está com o padrão dito pela tela de avaliações em relação a textos e as suas cores.

## Tarefas Relacionadas

* Issue: https://github.com/IFPBEsp/APAE-gestao-escolar/issues/272
* Outras dependências: {pr_link}

## Mudanças Realizadas

* Mudança nas fontes de textos para padronizar tamanho entre telas
* Mudança em algumas cores para padronizar como os texto são mostrados entre as telas

## Evidências

build:
<img width="1357" height="718" alt="build" src="https://github.com/user-attachments/assets/e3f2e5f0-2c21-40b3-9d5c-131813570957" />


antes:
<img width="1377" height="750" alt="antes1" src="https://github.com/user-attachments/assets/49d07578-ea7d-4f20-8458-79ffbfe718ee" />


depois:
<img width="1378" height="750" alt="depois" src="https://github.com/user-attachments/assets/aadabcc5-a631-4e3e-8c5f-1cf2d5199803" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Enhanced visual presentation of the Student Reports page with refined text colors and updated list styling for improved readability and layout consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->