### PR TITLE
[REFACTOR] Ajustar tamanho dos botões de avaliações e relatórios

### DIFF
--- a/app/src/app/professor/turmas/[turmaId]/alunos/page.tsx
+++ b/app/src/app/professor/turmas/[turmaId]/alunos/page.tsx
@@ -24,6 +24,24 @@ import { buscarTurmaPorId } from "@/services/TurmaService";
 import { format } from 'date-fns';
 import { ptBR } from 'date-fns/locale';
 
+interface ActionButtonProps {
+  variant: "primary" | "outline";
+  onClick: () => void;
+  label: string;
+  extraClass?: string;
+}
+
+const ActionButton = ({ variant, onClick, label, extraClass = "" }: ActionButtonProps) => (
+  <Button
+    variant={variant}
+    onClick={onClick}
+    className={`w-full !px-1 min-w-0 flex flex-col xl:flex-row items-center justify-center overflow-hidden gap-1 xl:gap-2 !h-auto py-2 xl:!py-0 xl:!h-12 ${extraClass}`}
+  >
+    <FileText className="h-4 w-4 lg:h-5 lg:w-5 shrink-0" />
+    <span className="text-[10px] sm:text-xs font-semibold truncate block">{label}</span>
+  </Button>
+);
+
 export default function TurmaDetalhesPage() {
   const params = useParams();
   const turmaId = params?.turmaId ? Number(params.turmaId) : null;
@@ -199,6 +217,8 @@ export default function TurmaDetalhesPage() {
                       onClick={() => setViewMode("grid")}
                       variant={viewMode === "grid" ? "primary" : "outline"}
                       className="flex-1 px-0 min-w-0"
+                      aria-label="Visualização em grade"
+                      title="Visualização em grade"
                     >
                       <Grid3x3 className="h-5 w-5" />
                     </Button>
@@ -207,6 +227,8 @@ export default function TurmaDetalhesPage() {
                       onClick={() => setViewMode("list")}
                       variant={viewMode === "list" ? "primary" : "outline"}
                       className="flex-1 px-0 min-w-0"
+                      aria-label="Visualização em lista"
+                      title="Visualização em lista"
                     >
                       <List className="h-5 w-5" />
                     </Button>
@@ -246,24 +268,17 @@ export default function TurmaDetalhesPage() {
                       </div>
                     </div>
 
-                    <div className="flex gap-2 w-full">
-                      <Button
+                    <div className="grid grid-cols-2 gap-2 w-full">
+                      <ActionButton
                         variant="primary"
                         onClick={() => handleAvaliacoes(aluno.id)}
-                        className="flex-1 px-2 min-w-0"
-                      >
-                        <FileText className="mr-1 h-4 w-4 sm:mr-2 sm:h-5 sm:w-5 shrink-0" />
-                        <span className="text-[11px] sm:text-sm font-semibold truncate block">Avaliações</span>
-                      </Button>
-
-                      <Button
-                        onClick={() => handleRelatorios(aluno.id)}
+                        label="Avaliações"
+                      />
+                      <ActionButton
                         variant="outline"
-                        className="flex-1 px-2 min-w-0"
-                      >
-                        <FileText className="mr-1 h-4 w-4 sm:mr-2 sm:h-5 sm:w-5 shrink-0" />
-                        <span className="text-[11px] sm:text-sm font-semibold truncate block">Relatórios</span>
-                      </Button>
+                        onClick={() => handleRelatorios(aluno.id)}
+                        label="Relatórios"
+                      />
                     </div>
                   </CardContent>
                 </Card>
@@ -298,24 +313,19 @@ export default function TurmaDetalhesPage() {
                             </div>
                           </div>
 
-                          <div className="flex gap-2 w-full md:w-auto">
-                            <Button
+                          <div className="grid grid-cols-2 gap-2 w-full md:w-auto md:flex md:flex-row">
+                            <ActionButton
+                              variant="outline"
                               onClick={() => handleAvaliacoes(aluno.id)}
+                              label="Avaliações"
+                              extraClass="md:flex-1 border-[#0D4F97] text-[#0D4F97]"
+                            />
+                            <ActionButton
                               variant="outline"
-                              className="flex-1 px-2 min-w-0 border-[#0D4F97] text-[#0D4F97]"
-                            >
-                              <FileText className="mr-1 h-4 w-4 sm:mr-2 sm:h-5 sm:w-5 shrink-0" />
-                              <span className="text-[11px] sm:text-sm font-semibold truncate block">Avaliações</span>
-                            </Button>
-
-                            <Button
                               onClick={() => handleRelatorios(aluno.id)}
-                              variant="outline"
-                              className="flex-1 px-2 min-w-0 border-[#0D4F97] text-[#0D4F97]"
-                            >
-                              <FileText className="mr-1 h-4 w-4 sm:mr-2 sm:h-5 sm:w-5 shrink-0" />
-                              <span className="text-[11px] sm:text-sm font-semibold truncate block">Relatórios</span>
-                            </Button>
+                              label="Relatórios"
+                              extraClass="md:flex-1 border-[#0D4F97] text-[#0D4F97]"
+                            />
                           </div>
                         </div>
                       </div>


### PR DESCRIPTION
# O que mudou?
Ajustar o layout dos botões no card do aluno na visão do professor, garantindo que "Avaliações" e "Relatórios" caibam perfeitamente na tela e não quebrem o design em dispositivos móveis e tablets.

## Tarefas Relacionadas

* Issue: {issue_link} #296 
* Outras dependências: {pr_link}

## Mudanças Realizadas

* Envolvemos os botões em um container de largura total (w-full).
* Adicionei a classe flex-1 para que ambos dividam o espaço do card exatamente em 50% / 50%.
* Removi os paddings excessivos gerados globalmente pelo componente base, aplicando localmente um padding menor (px-2).

## Evidências
<img width="1337" height="896" alt="Captura de tela 2026-03-24 193807" src="https://github.com/user-attachments/assets/70b559b4-218d-4b6b-9fc2-a524588ef6fd" />
<img width="990" height="854" alt="Captura de tela 2026-03-24 203324" src="https://github.com/user-attachments/assets/3abd3e26-ede2-48eb-92d7-1b242d46ac17" />
<img width="1000" height="836" alt="Captura de tela 2026-03-24 203342" src="https://github.com/user-attachments/assets/4c04acee-f641-4c47-9c2d-70f0d1554404" />
<img width="582" height="851" alt="Captura de tela 2026-03-24 203409" src="https://github.com/user-attachments/assets/55f2b28b-c9b2-4c16-8ff5-fe6ea60655a1" />
<img width="586" height="863" alt="Captura de tela 2026-03-24 203420" src="https://github.com/user-attachments/assets/8845e9e4-8143-4b4b-a40e-ccd2bdcb08be" />
<img width="527" height="853" alt="Captura de tela 2026-03-24 203431" src="https://github.com/user-attachments/assets/f9972d71-47f8-48df-aa18-5ab451d2d256" />
<img width="502" height="851" alt="Captura de tela 2026-03-24 203443" src="https://github.com/user-attachments/assets/bc52efc3-90ba-4c33-9724-0c14999b2a49" />
<img width="471" height="886" alt="Captura de tela 2026-03-24 203456" src="https://github.com/user-attachments/assets/5bfd60da-1d2f-4e73-b01e-78d809d708ef" />
<img width="456" height="873" alt="Captura de tela 2026-03-24 203505" src="https://github.com/user-attachments/assets/4e5f36d5-49f8-4246-b8b7-ab6167e235e4" />
<img width="1086" height="850" alt="Captura de tela 2026-03-24 203523" src="https://github.com/user-attachments/assets/e1c93ee4-2125-499f-8d45-61b3443b814a" />
<img width="1106" height="842" alt="Captura de tela 2026-03-24 203536" src="https://github.com/user-attachments/assets/193ee24c-2ba2-4cea-ba4e-da2b055bfcf5" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced a unified action button design for "Avaliações" and "Relatórios", ensuring consistent icons and responsive labels.

* **Bug Fixes**
  * Improved layout and spacing in grid and list views for clearer alignment and readability across screen sizes.
  * Adjusted view toggle sizing and added accessible labels/titles for better keyboard and screen-reader support.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->