### PR TITLE
[FIX] Garantir unicidade de nome ao editar turma

### DIFF
--- a/api/src/main/java/com/apae/gestao/repository/TurmaRepository.java
+++ b/api/src/main/java/com/apae/gestao/repository/TurmaRepository.java
@@ -15,6 +15,8 @@ public interface TurmaRepository extends JpaRepository<Turma, Long> {
 
     boolean existsByNome(String nome);
 
+    boolean existsByNomeAndIdNot(String nome, Long id);
+
     @Query("""
         SELECT new com.apae.gestao.dto.turma.TurmaResumoFrequenciaDTO(
             CAST(SUM(CASE WHEN p.faltou = false THEN 1.0 ELSE 0.0 END) * 100.0 / NULLIF(COUNT(p), 0) AS double),

--- a/api/src/main/java/com/apae/gestao/service/TurmaService.java
+++ b/api/src/main/java/com/apae/gestao/service/TurmaService.java
@@ -89,7 +89,7 @@ public class TurmaService {
     public TurmaResponseDTO criar(TurmaRequestDTO dto) {
         Turma turma = new Turma();
         mapearDtoParaEntity(dto, turma);
-        turma.setNome(obterNomeUnicoParaTurma(turma.getNome()));
+        turma.setNome(obterNomeUnicoParaTurma(turma.getNome(), null));
         Turma salvo = turmaDAO.save(turma);
         return new TurmaResponseDTO(salvo);
     }
@@ -97,9 +97,15 @@ public class TurmaService {
     /**
      * Garante um nome único para a turma. Se já existir turma com o mesmo nome,
      * adiciona sufixo numérico (2), (3), ... até encontrar um nome disponível.
+     *
+     * @param excludeId ID da turma a ser ignorada na verificação (usado na edição). Pode ser null na criação.
      */
-    private String obterNomeUnicoParaTurma(String nomeBase) {
-        if (!turmaDAO.existsByNome(nomeBase)) {
+    private String obterNomeUnicoParaTurma(String nomeBase, Long excludeId) {
+        boolean nomeExiste = excludeId == null
+                ? turmaDAO.existsByNome(nomeBase)
+                : turmaDAO.existsByNomeAndIdNot(nomeBase, excludeId);
+
+        if (!nomeExiste) {
             return nomeBase;
         }
         int sufixo = 2;
@@ -107,7 +113,10 @@ public class TurmaService {
         do {
             nomeCandidato = nomeBase + " (" + sufixo + ")";
             sufixo++;
-        } while (turmaDAO.existsByNome(nomeCandidato));
+            nomeExiste = excludeId == null
+                    ? turmaDAO.existsByNome(nomeCandidato)
+                    : turmaDAO.existsByNomeAndIdNot(nomeCandidato, excludeId);
+        } while (nomeExiste);
         return nomeCandidato;
     }
 
@@ -131,6 +140,7 @@ public class TurmaService {
         Turma turma = turmaDAO.findById(turmaId)
                 .orElseThrow(() -> new RuntimeException("Turma não encontrada com ID: " + turmaId));
         mapearDtoParaEntity(dto, turma);
+        turma.setNome(obterNomeUnicoParaTurma(turma.getNome(), turma.getId()));
         Turma atualizado = turmaDAO.save(turma);
         return new TurmaResponseDTO(atualizado);
     }


### PR DESCRIPTION
# O que mudou?

Corrige o bug onde a edição de turmas não verificava a unicidade do nome, permitindo que uma turma fosse renomeada para um nome já existente, quebrando a regra de sufixo numérico (n) aplicada na criação.
## Tarefas Relacionadas

* Issue: https://github.com/orgs/IFPBEsp/projects/14/views/1?pane=issue&itemId=167937657&issue=IFPBEsp%7CAPAE-gestao-escolar%7C294

## Mudanças Realizadas

* Adicionado o método existsByNomeAndIdNot no TurmaRepository para verificar duplicidade de nome excluindo a própria turma da busca
* Refatorado o método obterNomeUnicoParaTurma no TurmaService para aceitar um excludeId, permitindo que a edição não conflite consigo mesma
* Aplicada a verificação de unicidade de nome no método atualizar, garantindo consistência com a regra já existente na criação de turmas

## Evidências


https://github.com/user-attachments/assets/29bfb988-8ac1-4470-9d4c-7e1e9c469435



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved name uniqueness validation for turmas to support both creation and editing workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->