### PR TITLE
[FEATURE] Permitir alteração do ano ao editar turma

### DIFF
--- a/app/src/components/turmas/EditarTurmaModal.tsx
+++ b/app/src/components/turmas/EditarTurmaModal.tsx
@@ -66,6 +66,7 @@ interface EditarTurmaModalProps {
 export function EditarTurmaModal({ isOpen, onClose, turmaData, onSave }: EditarTurmaModalProps) {
     const [tipo, setTipo] = useState("");
     const [turno, setTurno] = useState("");
+    const [anoCriacao, setAnoCriacao] = useState("");
     
     const [buscaProfessor, setBuscaProfessor] = useState("");
     const [professoresEncontrados, setProfessoresEncontrados] = useState<Professor[]>([]);
@@ -76,8 +77,8 @@ export function EditarTurmaModal({ isOpen, onClose, turmaData, onSave }: EditarT
     const [alunosNaTurma, setAlunosNaTurma] = useState<AlunoNaTurma[]>([]); 
 
     const nomeTurma = useMemo(
-        () => `${tipo ? formatTipo(tipo) : ""} ${turmaData?.anoCriacao || ""} - ${turno ? formatTurno(turno) : ""}`,
-        [tipo, turno, turmaData]
+        () => `${tipo ? formatTipo(tipo) : ""} ${anoCriacao || ""} - ${turno ? formatTurno(turno) : ""}`,
+        [tipo, turno, anoCriacao]
     );
 
     function formatTipo(val: string) {
@@ -101,6 +102,7 @@ export function EditarTurmaModal({ isOpen, onClose, turmaData, onSave }: EditarT
 
                 setTipo(turmaBackend.tipo);
                 setTurno(turmaBackend.turno);
+                setAnoCriacao(turmaBackend.anoCriacao?.toString() || "");
 
                 if (turmaBackend.professorId && (turmaBackend.professorNome || turmaBackend.professor?.nome)) {
                     setProfessorSelecionado({
@@ -227,7 +229,7 @@ export function EditarTurmaModal({ isOpen, onClose, turmaData, onSave }: EditarT
             tipo: tipo.toUpperCase(),
             turno: turno.toUpperCase(),
             isAtiva: turmaData.isAtiva,
-            anoCriacao: turmaData.anoCriacao,
+            anoCriacao: Number(anoCriacao) || new Date().getFullYear(),
             alunosIds: alunosNaTurma.map(a => a.alunoId)
         };
 
@@ -270,7 +272,7 @@ export function EditarTurmaModal({ isOpen, onClose, turmaData, onSave }: EditarT
                     <div className="space-y-4">
                         <h3 className="text-[#0D4F97] font-medium border-b border-[#B2D7EC] pb-2">Informações Básicas</h3>
                         
-                        <div className="grid grid-cols-2 gap-4">
+                        <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
                             <div className="space-y-2">
                                 <Label className="text-[#0D4F97]">Tipo de Turma</Label>
                                 <Select onValueChange={setTipo} defaultValue={turmaData.tipo}>
@@ -282,6 +284,18 @@ export function EditarTurmaModal({ isOpen, onClose, turmaData, onSave }: EditarT
                                         <SelectItem value="ESTIMULACAO">Estimulação</SelectItem>
                                     </SelectContent>
                                 </Select>
+                            </div>
+
+                            <div className="space-y-2">
+                                <Label className="text-[#0D4F97]">Ano</Label>
+                                <Input
+                                    type="number"
+                                    min="2000"
+                                    max="2100"
+                                    value={anoCriacao}
+                                    onChange={(e) => setAnoCriacao(e.target.value)}
+                                    className="bg-white border-[#B2D7EC]"
+                                />
                             </div>
 
                             <div className="space-y-2">
@@ -306,7 +320,7 @@ export function EditarTurmaModal({ isOpen, onClose, turmaData, onSave }: EditarT
                                 className="bg-gray-50 border-[#B2D7EC]"
                             />
                             <p className="text-xs text-[#0D4F97]">
-                                O nome da turma é gerado a partir do Tipo, Ano ({turmaData.anoCriacao}) e Turno.
+                                O nome da turma é gerado a partir do Tipo, Ano e Turno alterados acima.
                             </p>
                         </div>
                     </div>

--- a/app/src/components/turmas/EditarTurmaModal.tsx
+++ b/app/src/components/turmas/EditarTurmaModal.tsx
@@ -217,6 +217,12 @@ export function EditarTurmaModal({ isOpen, onClose, turmaData, onSave }: EditarT
             return;
         }
 
+        const anoNumerico = Number(anoCriacao);
+        if (!Number.isInteger(anoNumerico) || anoNumerico < 2000 || anoNumerico > 2100) {
+            toast.error("Informe um ano válido entre 2000 e 2100.");
+            return;
+        }
+
         const idTurma = turmaData.id;
 
         const professorFinal = professorSelecionado;
@@ -229,7 +235,7 @@ export function EditarTurmaModal({ isOpen, onClose, turmaData, onSave }: EditarT
             tipo: tipo.toUpperCase(),
             turno: turno.toUpperCase(),
             isAtiva: turmaData.isAtiva,
-            anoCriacao: Number(anoCriacao) || new Date().getFullYear(),
+            anoCriacao: anoNumerico,
             alunosIds: alunosNaTurma.map(a => a.alunoId)
         };
 


### PR DESCRIPTION
# O que mudou?

Atualmente, o sistema exibia o ano da turma apenas de forma estática (como leitura), travando o valor definido no momento da criação. Isso era um bloqueio administrativo, já que impossibilitava a correção rápida de eventuais erros de digitação durante o cadastro da turma.

## Tarefas Relacionadas

* Issue: {issue_link} #297 
* Outras dependências: {pr_link}

## Mudanças Realizadas

* Interface Gráfica (EditarTurmaModal.tsx): O layout do cabeçalho foi ajustado para incluir um novo formulário de Input numérico dedicado ao Ano.
* Reatividade: A formação automática do "Nome da Turma" foi conectada a este novo Input, permitindo que o administrador visualize a mudança do nome em tempo real enquanto digita o novo ano.
* Persistência de Dados: O fluxo de salvamento foi parametrizado para resgatar o valor digitado via estado (useState) e transmiti-lo no payload da requisição atualizarTurma para que o backend grave a alteração permanentemente. As demais lógicas da turma (gerenciamento de alunos e do professor) permanecem intactas e isoladas dessa mudança.

## Evidências
<img width="1907" height="996" alt="Captura de tela 2026-03-24 210230" src="https://github.com/user-attachments/assets/4ecc2137-5705-44f3-94f3-081e441fc580" />
<img width="1888" height="961" alt="Captura de tela 2026-03-24 210300" src="https://github.com/user-attachments/assets/40152a21-beb7-49a1-9edd-ba45de31e510" />
<img width="1483" height="963" alt="Captura de tela 2026-03-24 210325" src="https://github.com/user-attachments/assets/e1243d66-67a8-4d6a-9051-549589541739" />
<img width="1240" height="893" alt="image" src="https://github.com/user-attachments/assets/6f56016f-d95c-465b-aa3d-8e7a2a55b1c2" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added editable "Ano" field when modifying class info with numeric input (2000–2100).
  * Year value is validated and saved as a numeric year.
  * "Informações Básicas" layout updated to a responsive three-column design.
  * Helper text updated to reference the fields changed above (Tipo, Ano e Turno), and the "Nome da Turma" control now updates its disabled state based on the local year value.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->