### PR TITLE
[BUG] Impedir acesso de professores inativos ao sistema

### DIFF
--- a/api/src/main/java/com/apae/gestao/service/AuthService.java
+++ b/api/src/main/java/com/apae/gestao/service/AuthService.java
@@ -53,6 +53,11 @@ public class AuthService {
         Professor professor = professorRepository.findByEmail(request.getEmail())
                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.UNAUTHORIZED, "Professor não encontrado"));
 
+        //validação de professor ativo no sistema
+        if(!professor.getAtivo()){
+            throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "Professor inativado no sistema");
+        }
+
         // Validação da senha informada
         if (!passwordEncoder.matches(request.getSenha(), professor.getSenha())) {
             throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "Senha incorreta");

--- a/app/src/components/Login.tsx
+++ b/app/src/components/Login.tsx
@@ -53,6 +53,8 @@ export default function LoginComponent({ tipoPredefinido }: LoginProps) {
 
       if (message && message.includes("PRIMEIRO_ACESSO")) {
         router.push(`/primeiro-acesso?email=${email}`);
+      } else if (message && message.includes("Professor inativado no sistema")){
+        setErro("Professor inativo no sistema");
       } else {
         setErro("E-mail ou senha inválidos.");
       }


### PR DESCRIPTION
Close #291 

# O que mudou?

Agora professores inativos no sistema não poderão mais acessar a página de professor, mostrando um aviso ao tentar logar como um professor desativado na página de login.

## Tarefas Relacionadas

* Issue: https://github.com/IFPBEsp/APAE-gestao-escolar/issues/291
* Outras dependências: {pr_link}

## Mudanças Realizadas

* Mudança no AuthService na função de login na parte de professores, agora possui uma checagem de if(!professor.getAtivo())
* Mudança no componente de Login, na função de loginService com tratamento de else if (message && message.includes("Professor inativado no sistema")) para exibir mensagem


## Evidências

build:
<img width="1357" height="716" alt="build" src="https://github.com/user-attachments/assets/273474b5-bcc0-45e2-94a8-047561b6ba78" />

antes:
https://github.com/user-attachments/assets/93657fe3-4633-4cd1-b81b-9895ad36a3e5

depois:
https://github.com/user-attachments/assets/c367bc53-df4e-4331-a85a-fbc68eb3783a

