### PR TITLE
fix: exibir alunos ativos e inativos na edição de turma

### DIFF
--- a/api/src/main/java/com/apae/gestao/dto/turma/TurmaResponseDTO.java
+++ b/api/src/main/java/com/apae/gestao/dto/turma/TurmaResponseDTO.java
@@ -63,7 +63,6 @@ public class TurmaResponseDTO {
 
         if (turma.getTurmaAlunos() != null) {
             this.alunos = turma.getTurmaAlunos().stream()
-                    .filter(ta -> Boolean.TRUE.equals(ta.getIsAlunoAtivo()))
                     .map(TurmaAlunoResponseDTO::new)
                     .collect(Collectors.toList());
         }

--- a/api/src/main/java/com/apae/gestao/service/TurmaService.java
+++ b/api/src/main/java/com/apae/gestao/service/TurmaService.java
@@ -230,7 +230,6 @@ public class TurmaService {
     public List<TurmaAlunoResponseDTO> listarAlunos(Long turmaId) {
         return turmaAlunoDAO.findByTurmaIdOrderByAlunoNomeAsc(turmaId)
                 .stream()
-                .filter(ta -> Boolean.TRUE.equals(ta.getIsAlunoAtivo()))
                 .map(TurmaAlunoResponseDTO::new)
                 .toList();
     }

--- a/app/src/components/turmas/EditarTurmaModal.tsx
+++ b/app/src/components/turmas/EditarTurmaModal.tsx
@@ -388,8 +388,15 @@ export function EditarTurmaModal({ isOpen, onClose, turmaData, onSave }: EditarT
                                             <div className="h-8 w-8 bg-[#E8F3FF] rounded-full flex items-center justify-center text-[#0D4F97]">
                                                 <UserRound size={18} />
                                             </div>
-                                            <div>
+                                            <div className="flex items-center gap-2">
                                                 <p className="text-sm font-semibold text-[#0D4F97]">{aluno.nome}</p>
+                                                <span className={`inline-flex rounded-full px-2 py-0.5 text-xs font-medium ${
+                                                    aluno.isAtivo !== false
+                                                        ? "bg-green-100 text-green-700"
+                                                        : "bg-red-100 text-red-700"
+                                                }`}>
+                                                    {aluno.isAtivo !== false ? "Ativo" : "Inativo"}
+                                                </span>
                                             </div>
                                         </div>
                                         <Button


### PR DESCRIPTION
# O que mudou?

Na tela de edição de turma, ao inativar um aluno, ele desaparecia da lista porque o backend retornava apenas alunos com vínculo ativo. Isso impedia a visualização e reativação de alunos inativos pela mesma interface. Este PR remove os filtros que excluíam alunos inativos das listagens e adiciona indicador visual de status no modal de edição.

## Tarefas Relacionadas

* Issue: https://github.com/orgs/IFPBEsp/projects/14/views/1?pane=issue&itemId=169923821&issue=IFPBEsp%7CAPAE-gestao-escolar%7C310

## Mudanças Realizadas

* Removido filtro .filter(ta -> Boolean.TRUE.equals(ta.getIsAlunoAtivo())) em TurmaService.listarAlunos(), fazendo o endpoint GET /turmas/{id}/alunos retornar todos os alunos (ativos e inativos). Os endpoints dedicados /alunos/ativos e /alunos/inativos permanecem inalterados.

* Removido o mesmo filtro no construtor de TurmaResponseDTO, garantindo que respostas após operações (ativar, inativar, atualizar turma) também incluam todos os alunos vinculados.

* Adicionado badge de status ("Ativo" em verde / "Inativo" em vermelho) ao lado do nome de cada aluno no EditarTurmaModal, seguindo o padrão visual já existente em DetalhesTurma.

## Evidências


https://github.com/user-attachments/assets/30f4dae6-bd67-4218-8856-4dab11d2e940




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Features**
  * Student lists now display both active and inactive students instead of filtering out inactive ones.

* **UI Improvements**
  * Added status badges next to student names indicating whether each student is active or inactive.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->