### PR TITLE
[REFACTOR] Padronizar formatação de tipo e turno na criação de turma

### DIFF
--- a/api/src/main/java/com/apae/gestao/service/TurmaService.java
+++ b/api/src/main/java/com/apae/gestao/service/TurmaService.java
@@ -14,7 +14,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 
-import com.apae.gestao.dto.ProfessorResponseDTO;
+
 import com.apae.gestao.dto.turma.TurmaRequestDTO;
 import com.apae.gestao.dto.turma.TurmaResponseDTO;
 import com.apae.gestao.dto.turmaAluno.TurmaAlunoResponseDTO;
@@ -297,7 +297,7 @@ public class TurmaService {
         turma.setAnoCriacao(dto.getAnoCriacao());
         turma.setTurno(dto.getTurno());
         turma.setTipo(dto.getTipo());
-        turma.setNome(dto.getTipo() + " " + dto.getAnoCriacao() + " " + dto.getTurno());
+        turma.setNome(dto.getTipo() + " " + dto.getAnoCriacao() + " - " + dto.getTurno());
 
         if (dto.getIsAtiva() != null) {
             turma.setIsAtiva(dto.getIsAtiva());

--- a/app/src/components/turmas/EditarTurmaModal.tsx
+++ b/app/src/components/turmas/EditarTurmaModal.tsx
@@ -224,8 +224,8 @@ export function EditarTurmaModal({ isOpen, onClose, turmaData, onSave }: EditarT
         }
 
         const dadosAtualizados: any = {
-            tipo: tipo.toUpperCase(),
-            turno: turno.toUpperCase(),
+            tipo: formatTipo(tipo),
+            turno: formatTurno(turno),
             isAtiva: turmaData.isAtiva,
             anoCriacao: turmaData.anoCriacao,
             alunosIds: alunosNaTurma.map(a => a.alunoId)

--- a/app/src/components/turmas/NovaTurmaModal.tsx
+++ b/app/src/components/turmas/NovaTurmaModal.tsx
@@ -63,6 +63,7 @@ export function NovaTurmaModal({ isOpen, onClose, onSave }: NovaTurmaModalProps)
 
     function formatTipo(val: string) {
         if (val === 'alfabetizacao') return 'Alfabetização';
+        if (val === 'estimulacao') return 'Estimulação';
         if (val === 'matematica') return 'Matemática';
         return val;
     }
@@ -146,9 +147,9 @@ export function NovaTurmaModal({ isOpen, onClose, onSave }: NovaTurmaModalProps)
         }
 
         const dadosNovaTurma = {
-            tipo: tipo.toUpperCase(),
+            tipo: formatTipo(tipo),
             anoCriacao: Number(ano),
-            turno: turno.toUpperCase(),
+            turno: formatTurno(turno),
             professorId: professorSelecionado.id,
             isAtiva: true,
             alunosIds: alunosSelecionados.map(a => a.id)
@@ -215,7 +216,7 @@ export function NovaTurmaModal({ isOpen, onClose, onSave }: NovaTurmaModalProps)
                                     Alfabetização
                                 </SelectItem>
                                 <SelectItem
-                                    value="Estimulação"
+                                    value="estimulacao"
                                     className="cursor-pointer hover:bg-[#D0E7FA] focus:bg-[#D0E7FA] transition-colors"
                                 >
                                     Estimulação


### PR DESCRIPTION
Close #301 

# O que mudou?

Agora os dados de tipo e ano da turma estão com case e ascentuação corretos, no mapearDtoParaEntity estão separados por " - " .

## Tarefas Relacionadas

* Issue: https://github.com/IFPBEsp/APAE-gestao-escolar/issues/301
* Outras dependências: {pr_link}

## Mudanças Realizadas

* Mudança no NovaTurma modal no handleSave, dadosDeTurma para passar o format para tipo e ano.
* Mudança no TurmaService no mapearDtoParaEntity para separar tipo e ano com " - ".
* Mudança no EditarTurma modal no handleSave para passar as formatações corretas assim como no NovaTurmaModal.

## Evidências

build:

<img width="1357" height="717" alt="build" src="https://github.com/user-attachments/assets/4d9e131b-2270-4386-b474-8386e4284d33" />

antes:
https://github.com/user-attachments/assets/fad03058-5aa3-4fb3-8407-9452d361d688

depois:
https://github.com/user-attachments/assets/345a7743-f842-43ed-9411-c9a4c49b345e



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added "Estimulação" as a selectable class type option, with selection behavior aligned to formatting rules.

* **Improvements**
  * Class names now include a separator between type, creation year, and shift (e.g., "Tipo Ano - Turno").
  * Standardized type and shift formatting across class creation and editing so persisted values use the formatted labels.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->