### PR TITLE
feat: listar historico de turmas vinculadas ao aluno

### DIFF
--- a/api/src/main/java/com/apae/gestao/controller/AlunoController.java
+++ b/api/src/main/java/com/apae/gestao/controller/AlunoController.java
@@ -4,6 +4,7 @@ import com.apae.gestao.dto.AlunoTurmaRequestDTO;
 import com.apae.gestao.dto.AvaliacaoHistoricoResponseDTO;
 import com.apae.gestao.dto.aluno.AlunoDetalhesDTO;
 import com.apae.gestao.dto.aluno.AlunoResumoDTO;
+import com.apae.gestao.dto.aluno.AlunoTurmaHistoricoItemDTO;
 import com.apae.gestao.service.AlunoService;
 
 import io.swagger.v3.oas.annotations.Operation;
@@ -93,5 +94,20 @@ public class AlunoController {
                 alunoService.buscarAvaliacoesPorAlunoId(id);
 
         return ResponseEntity.ok(avaliacoes);
+    }
+
+    @GetMapping("/{id}/turmas")
+    @Operation(
+        summary = "Listar histórico de turmas do aluno",
+        description = "Retorna todas as turmas em que o aluno possui ou possuiu vínculo (ativas ou inativas, vínculo atual ou antigo)."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Lista retornada com sucesso"),
+            @ApiResponse(responseCode = "404", description = "Aluno não encontrado")
+    })
+    public ResponseEntity<List<AlunoTurmaHistoricoItemDTO>> listarHistoricoTurmasPorAlunoId(
+            @PathVariable Long id
+    ) {
+        return ResponseEntity.ok(alunoService.listarHistoricoTurmasPorAlunoId(id));
     }
 }

--- a/api/src/main/java/com/apae/gestao/dto/aluno/AlunoTurmaHistoricoItemDTO.java
+++ b/api/src/main/java/com/apae/gestao/dto/aluno/AlunoTurmaHistoricoItemDTO.java
@@ -1,0 +1,76 @@
+package com.apae.gestao.dto.aluno;
+
+import com.apae.gestao.entity.Turma;
+import com.apae.gestao.entity.TurmaAluno;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Schema(description = "Turma em que o aluno possui ou possuiu vínculo (histórico acadêmico).")
+public class AlunoTurmaHistoricoItemDTO {
+
+    @Schema(description = "Identificador da turma", example = "7")
+    private Long id;
+
+    @Schema(description = "Nome da turma", example = "Alfabetização 2025 - Manhã")
+    private String nome;
+
+    @Schema(description = "Ano de criação da turma", example = "2025")
+    private Integer anoCriacao;
+
+    @Schema(description = "Turno (MANHA, TARDE, NOITE)", example = "MANHA")
+    private String turno;
+
+    @Schema(description = "Tipo pedagógico", example = "Educação Especial")
+    private String tipo;
+
+    @Schema(description = "Indica se a turma está ativa no sistema", example = "true")
+    private Boolean isAtiva;
+
+    @Schema(description = "Nome do professor responsável", example = "Maria da Silva")
+    private String professorNome;
+
+    @Schema(description = "ID do professor responsável", example = "12")
+    private Long professorId;
+
+    @Schema(description = "Indica se este é o vínculo ativo (turma atual) do aluno", example = "false")
+    private Boolean isAlunoAtivo;
+
+    @Schema(description = "Horário de aula conforme o turno", example = "Segunda a Sexta - 8h as 12h")
+    private String horario;
+
+    public AlunoTurmaHistoricoItemDTO(TurmaAluno turmaAluno) {
+        Turma turma = turmaAluno.getTurma();
+        this.id = turma.getId();
+        this.nome = turma.getNome();
+        this.anoCriacao = turma.getAnoCriacao();
+        this.turno = turma.getTurno();
+        this.tipo = turma.getTipo();
+        this.isAtiva = turma.getIsAtiva();
+        if (turma.getProfessor() != null) {
+            this.professorNome = turma.getProfessor().getNome();
+            this.professorId = turma.getProfessor().getId();
+        }
+        this.isAlunoAtivo = turmaAluno.getIsAlunoAtivo();
+        this.horario = horarioPorTurno(turma.getTurno());
+    }
+
+    private static String horarioPorTurno(String turno) {
+        if (turno == null) {
+            return "Horário não definido";
+        }
+        switch (turno.toUpperCase()) {
+            case "MANHA":
+                return "Segunda a Sexta - 8h as 12h";
+            case "TARDE":
+                return "Segunda a Sexta - 14h as 18h";
+            default:
+                return "Horário não definido";
+        }
+    }
+}

--- a/api/src/main/java/com/apae/gestao/repository/TurmaAlunoRepository.java
+++ b/api/src/main/java/com/apae/gestao/repository/TurmaAlunoRepository.java
@@ -4,6 +4,8 @@ import java.util.List;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import com.apae.gestao.entity.Aluno;
@@ -20,6 +22,15 @@ public interface TurmaAlunoRepository extends JpaRepository<TurmaAluno, Long>{
     Optional<TurmaAluno> findByTurmaAndAluno(Turma turma, Aluno aluno);
 
     List<TurmaAluno> findAllByAlunoAndIsAlunoAtivoTrue(Aluno aluno);
+
+    @Query("""
+            SELECT DISTINCT ta FROM TurmaAluno ta
+            JOIN FETCH ta.turma t
+            LEFT JOIN FETCH t.professor
+            WHERE ta.aluno = :aluno
+            ORDER BY t.anoCriacao DESC, t.nome ASC
+            """)
+    List<TurmaAluno> findAllHistoricoByAluno(@Param("aluno") Aluno aluno);
 
     List<TurmaAluno> findByTurmaId(Long turmaId);
 

--- a/api/src/main/java/com/apae/gestao/service/AlunoService.java
+++ b/api/src/main/java/com/apae/gestao/service/AlunoService.java
@@ -4,6 +4,7 @@ import com.apae.gestao.dto.AlunoTurmaRequestDTO;
 import com.apae.gestao.dto.AvaliacaoHistoricoResponseDTO;
 import com.apae.gestao.dto.aluno.AlunoDetalhesDTO;
 import com.apae.gestao.dto.aluno.AlunoResumoDTO;
+import com.apae.gestao.dto.aluno.AlunoTurmaHistoricoItemDTO;
 import com.apae.gestao.entity.Aluno;
 import com.apae.gestao.entity.Turma;
 import com.apae.gestao.entity.TurmaAluno;
@@ -121,6 +122,16 @@ public class AlunoService {
                 .findByAlunoOrderByDataAvaliacaoDesc(aluno)
                 .stream()
                 .map(a -> AvaliacaoHistoricoResponseDTO.fromEntity(a, turmaAtual))
+                .toList();
+    }
+
+    @Transactional(readOnly = true)
+    public List<AlunoTurmaHistoricoItemDTO> listarHistoricoTurmasPorAlunoId(Long alunoId) {
+        Aluno aluno = alunoRepository.findById(alunoId)
+                .orElseThrow(() -> new RuntimeException("Aluno não encontrado"));
+
+        return turmaAlunoRepository.findAllHistoricoByAluno(aluno).stream()
+                .map(AlunoTurmaHistoricoItemDTO::new)
                 .toList();
     }
 }


### PR DESCRIPTION
# O que mudou?
Foi implementado o suporte no backend para listar o histórico acadêmico de turmas de um aluno: todas as turmas em que ele já teve vínculo, incluindo vínculos ativos e inativos e turmas ativas ou inativas no cadastro. Isso atende a necessidade de visualizar o histórico completo sem depender apenas da turma atual.

## Tarefas Relacionadas

* Issue: https://github.com/orgs/IFPBEsp/projects/14/views/1?pane=issue&itemId=171402790&issue=IFPBEsp%7CAPAE-gestao-escolar%7C317

## Mudanças Realizadas

* Novo endpoint GET /api/alunos/{id}/turmas retornando a lista de turmas vinculadas ao aluno.

* Método listarHistoricoTurmasPorAlunoId em AlunoService, reutilizável por outros serviços.

* Consulta findAllHistoricoByAluno em TurmaAlunoRepository com fetch de turma e professor, ordenação por ano (desc) e nome da turma.

* Novo DTO AlunoTurmaHistoricoItemDTO com dados da turma, professor e flag isAlunoAtivo no vínculo.

* Documentação OpenAPI no controller (resumo, descrição e respostas).

## Evidências

<img width="997" height="652" alt="image" src="https://github.com/user-attachments/assets/c2ffefc8-dba8-403e-8219-2c6f5ca5eabd" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added API endpoint to retrieve a student's complete class history, including class details, schedule information, professor assignment, and enrollment status.

* **Documentation**
  * Enhanced Swagger/OpenAPI documentation for the new endpoint with proper error response descriptions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->