### PR TITLE
[Feature] Exibir historico de turmas do aluno na tela de detalhes

### DIFF
--- a/api/src/main/java/com/apae/gestao/controller/AlunoController.java
+++ b/api/src/main/java/com/apae/gestao/controller/AlunoController.java
@@ -4,6 +4,7 @@ import com.apae.gestao.dto.AlunoTurmaRequestDTO;
 import com.apae.gestao.dto.AvaliacaoHistoricoResponseDTO;
 import com.apae.gestao.dto.aluno.AlunoDetalhesDTO;
 import com.apae.gestao.dto.aluno.AlunoResumoDTO;
+import com.apae.gestao.dto.aluno.AlunoTurmaHistoricoResponseDTO;
 import com.apae.gestao.service.AlunoService;
 
 import io.swagger.v3.oas.annotations.Operation;
@@ -93,5 +94,16 @@ public class AlunoController {
                 alunoService.buscarAvaliacoesPorAlunoId(id);
 
         return ResponseEntity.ok(avaliacoes);
+    }
+
+    @GetMapping("/{id}/turmas/historico")
+    @Operation(summary = "Buscar histórico de turmas do aluno (vínculos ativos e anteriores)")
+    public ResponseEntity<List<AlunoTurmaHistoricoResponseDTO>> buscarHistoricoTurmasPorAlunoId(
+            @PathVariable Long id
+    ) {
+        List<AlunoTurmaHistoricoResponseDTO> historico =
+                alunoService.buscarHistoricoTurmasPorAlunoId(id);
+
+        return ResponseEntity.ok(historico);
     }
 }

--- a/api/src/main/java/com/apae/gestao/controller/AlunoController.java
+++ b/api/src/main/java/com/apae/gestao/controller/AlunoController.java
@@ -4,6 +4,8 @@ import com.apae.gestao.dto.AlunoTurmaRequestDTO;
 import com.apae.gestao.dto.AvaliacaoHistoricoResponseDTO;
 import com.apae.gestao.dto.aluno.AlunoDetalhesDTO;
 import com.apae.gestao.dto.aluno.AlunoResumoDTO;
+import com.apae.gestao.dto.aluno.AlunoTurmaHistoricoItemDTO;
+import com.apae.gestao.dto.aluno.AlunoTurmaHistoricoResponseDTO;
 import com.apae.gestao.service.AlunoService;
 
 import io.swagger.v3.oas.annotations.Operation;

--- a/api/src/main/java/com/apae/gestao/dto/aluno/AlunoTurmaHistoricoResponseDTO.java
+++ b/api/src/main/java/com/apae/gestao/dto/aluno/AlunoTurmaHistoricoResponseDTO.java
@@ -1,0 +1,42 @@
+package com.apae.gestao.dto.aluno;
+
+import com.apae.gestao.entity.Turma;
+import com.apae.gestao.entity.TurmaAluno;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Schema(description = "Registro do histórico de participação do aluno em turmas.")
+public class AlunoTurmaHistoricoResponseDTO {
+
+    @Schema(description = "Identificador da turma", example = "12")
+    private Long turmaId;
+
+    @Schema(description = "Tipo pedagógico da turma", example = "Educação Especial")
+    private String tipo;
+
+    @Schema(description = "Ano letivo da turma", example = "2025")
+    private Integer ano;
+
+    @Schema(description = "Turno da turma", example = "MANHA")
+    private String turno;
+
+    @Schema(description = "Indica se este é o vínculo ativo (turma atual) do aluno")
+    private Boolean turmaAtual;
+
+    public static AlunoTurmaHistoricoResponseDTO from(TurmaAluno ta) {
+        Turma t = ta.getTurma();
+        return new AlunoTurmaHistoricoResponseDTO(
+                t.getId(),
+                t.getTipo(),
+                t.getAnoCriacao(),
+                t.getTurno(),
+                Boolean.TRUE.equals(ta.getIsAlunoAtivo())
+        );
+    }
+}

--- a/api/src/main/java/com/apae/gestao/dto/turma/TurmaResponseDTO.java
+++ b/api/src/main/java/com/apae/gestao/dto/turma/TurmaResponseDTO.java
@@ -3,7 +3,6 @@ package com.apae.gestao.dto.turma;
 import java.util.List;
 import java.util.stream.Collectors;
 
-import com.apae.gestao.dto.ProfessorResponseDTO;
 import com.apae.gestao.dto.turmaAluno.TurmaAlunoResponseDTO;
 import com.apae.gestao.entity.Turma;
 import io.swagger.v3.oas.annotations.media.ArraySchema;

--- a/api/src/main/java/com/apae/gestao/repository/TurmaAlunoRepository.java
+++ b/api/src/main/java/com/apae/gestao/repository/TurmaAlunoRepository.java
@@ -4,6 +4,8 @@ import java.util.List;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import com.apae.gestao.entity.Aluno;
@@ -24,4 +26,12 @@ public interface TurmaAlunoRepository extends JpaRepository<TurmaAluno, Long>{
     List<TurmaAluno> findByTurmaId(Long turmaId);
 
     List<TurmaAluno> findByTurmaIdOrderByAlunoNomeAsc(Long turmaId);
+
+    @Query("""
+            SELECT ta FROM TurmaAluno ta
+            JOIN FETCH ta.turma t
+            WHERE ta.aluno = :aluno
+            ORDER BY ta.isAlunoAtivo DESC, t.anoCriacao DESC, t.nome ASC
+            """)
+    List<TurmaAluno> findHistoricoCompletoPorAluno(@Param("aluno") Aluno aluno);
 }

--- a/api/src/main/java/com/apae/gestao/service/AlunoService.java
+++ b/api/src/main/java/com/apae/gestao/service/AlunoService.java
@@ -4,6 +4,7 @@ import com.apae.gestao.dto.AlunoTurmaRequestDTO;
 import com.apae.gestao.dto.AvaliacaoHistoricoResponseDTO;
 import com.apae.gestao.dto.aluno.AlunoDetalhesDTO;
 import com.apae.gestao.dto.aluno.AlunoResumoDTO;
+import com.apae.gestao.dto.aluno.AlunoTurmaHistoricoResponseDTO;
 import com.apae.gestao.entity.Aluno;
 import com.apae.gestao.entity.Turma;
 import com.apae.gestao.entity.TurmaAluno;
@@ -105,6 +106,16 @@ public class AlunoService {
 
         turmaAlunoRepository.save(vinculo);
         return new AlunoDetalhesDTO(aluno);
+    }
+
+    @Transactional(readOnly = true)
+    public List<AlunoTurmaHistoricoResponseDTO> buscarHistoricoTurmasPorAlunoId(Long id) {
+        Aluno aluno = alunoRepository.findById(id)
+                .orElseThrow(() -> new RuntimeException("Aluno não encontrado"));
+
+        return turmaAlunoRepository.findHistoricoCompletoPorAluno(aluno).stream()
+                .map(AlunoTurmaHistoricoResponseDTO::from)
+                .toList();
     }
 
     @Transactional(readOnly = true)

--- a/app/src/app/admin/alunos/detalhes/[id]/page.tsx
+++ b/app/src/app/admin/alunos/detalhes/[id]/page.tsx
@@ -8,7 +8,9 @@ import { useRouter } from "next/navigation";
 import { useState, useEffect, useMemo, use } from "react"; 
 import ModalVisualizarAvaliacao from "@/components/alunos/ModalVisualizarAvaliacao";
 import ModalVisualizarRelatorio from "@/components/alunos/ModalVisualizarRelatorio";
-import { buscarAlunoPorId, buscarAvaliacoesPorAlunoId } from "@/services/AlunoService"; 
+import ModalHistoricoFrequencia from "@/components/frequencia/ModalHistoricoFrequencia";
+import { buscarAlunoPorId, buscarAvaliacoesPorAlunoId, buscarHistoricoTurmasPorAlunoId } from "@/services/AlunoService"; 
+import { getHistoricoAluno } from "@/services/ChamadaService";
 import { format } from "date-fns";
 import { ptBR } from "date-fns/locale"; 
 import { buscarRelatorioPorAluno } from "@/services/RelatorioService";
@@ -43,6 +45,14 @@ interface RelatorioHistoricoDTO {
   recursos: string;
 }
 
+interface AlunoTurmaHistoricoDTO {
+  turmaId: number;
+  tipo: string | null;
+  ano: number;
+  turno: string;
+  turmaAtual: boolean;
+}
+
 export default function DetalhesDoAluno({ params }: { params: Promise<{ id: string }> }) {
   const router = useRouter();
   const resolvedParams = use(params); 
@@ -51,11 +61,17 @@ export default function DetalhesDoAluno({ params }: { params: Promise<{ id: stri
   const [alunoData, setAlunoData] = useState<AlunoDetailDTO | null>(null);
   const [avaliacoes, setAvaliacoes] = useState<AvaliacaoHistoricoDTO[]>([]);
   const [relatorios, setRelatorios] = useState<RelatorioHistoricoDTO[]>([]);
+  const [historicoTurmas, setHistoricoTurmas] = useState<AlunoTurmaHistoricoDTO[]>([]);
   const [loadingAluno, setLoadingAluno] = useState(true);
   const [loadingAvaliacoes, setLoadingAvaliacoes] = useState(true);
   const [loadingRelatorios, setLoadingRelatorios] = useState(true);
+  const [loadingHistoricoTurmas, setLoadingHistoricoTurmas] = useState(true);
   const [selectedAvaliacao, setSelectedAvaliacao] = useState<any>(null); 
   const [selectedRelatorio, setSelectedRelatorio] = useState<any>(null); 
+  const [isHistoricoOpen, setIsHistoricoOpen] = useState(false);
+  const [historicoAluno, setHistoricoAluno] = useState<any[]>([]);
+  const [loadingHistorico, setLoadingHistorico] = useState(false);
+  const [turmaSelecionada, setTurmaSelecionada] = useState<any | null>(null);
 
   useEffect(() => {
     async function loadAlunoData() {
@@ -107,6 +123,45 @@ export default function DetalhesDoAluno({ params }: { params: Promise<{ id: stri
     }
     loadRelatorios();
   }, [alunoId]);
+
+  useEffect(() => {
+    async function loadHistoricoTurmas() {
+      setLoadingHistoricoTurmas(true);
+      try {
+        if (alunoId) {
+          const data = await buscarHistoricoTurmasPorAlunoId(alunoId);
+          setHistoricoTurmas(data);
+        }
+      } catch (error) {
+        console.error("Erro ao carregar histórico de turmas:", error);
+      } finally {
+        setLoadingHistoricoTurmas(false);
+      }
+    }
+    loadHistoricoTurmas();
+  }, [alunoId]);
+
+  async function handleAbrirHistoricoTurma(item: AlunoTurmaHistoricoDTO) {
+    if (!alunoId || !item?.turmaId) {
+      console.error("Dados inválidos para buscar histórico");
+      return;
+    }
+
+    try {
+      setTurmaSelecionada(item);
+      setIsHistoricoOpen(true);
+      setLoadingHistorico(true);
+      setHistoricoAluno([]);
+
+      const historico = await getHistoricoAluno(item.turmaId, alunoId);
+
+      setHistoricoAluno(historico);
+    } catch (error) {
+      console.error("Erro ao carregar histórico:", error);
+    } finally {
+      setLoadingHistorico(false);
+    }
+  }
 
   const turmaCompleta = useMemo(() => {
       if (!alunoData) return "Carregando...";
@@ -497,6 +552,108 @@ export default function DetalhesDoAluno({ params }: { params: Promise<{ id: stri
               </div>
             )}
 
+            {/* HISTÓRICO DE TURMAS */}
+            <div className="mt-10 border-t-8 border-[#E2E8F0] pt-8">
+              <h2 className="text-xl font-bold text-[#0D4F97] mb-2">
+                Histórico de Turmas
+              </h2>
+
+              <p className="text-gray-500 mb-6">
+                Turmas em que o aluno já esteve vinculado ({historicoTurmas.length} registros).
+              </p>
+
+              {loadingHistoricoTurmas ? (
+                <div className="flex justify-center py-4">
+                  <Loader2 className="h-6 w-6 animate-spin text-[#0D4F97]" />
+                </div>
+              ) : historicoTurmas.length === 0 ? (
+                <p className="text-center text-gray-500 py-4">
+                  Nenhum registro de turma encontrado para este aluno.
+                </p>
+              ) : (
+                <div className="overflow-x-auto max-h-80 overflow-y-auto border-2 border-[#B2D7EC] rounded-lg">
+                  <Table className="w-full min-w-[560px] table-fixed">
+                    
+                    <colgroup>
+                      <col style={{ width: "160px" }} />
+                      <col style={{ width: "100px" }} />
+                      <col style={{ width: "110px" }} />
+                      <col style={{ width: "140px" }} />
+                      <col style={{ width: "100px" }} />
+                    </colgroup>
+
+                    <TableHeader className="sticky top-0 z-20 bg-[#EAF4FB]">
+                      <TableRow className="bg-[#EAF4FB] hover:bg-[#EAF4FB]">
+
+                        <TableHead className="text-[#0D4F97] font-semibold px-4 sm:px-6">
+                          Turma
+                        </TableHead>
+
+                        <TableHead className="text-[#0D4F97] font-semibold px-4 sm:px-6">
+                          Ano
+                        </TableHead>
+
+                        <TableHead className="text-[#0D4F97] font-semibold px-4 sm:px-6">
+                          Turno
+                        </TableHead>
+
+                        <TableHead className="text-[#0D4F97] font-semibold px-4 sm:px-6">
+                          Situação
+                        </TableHead>
+
+                        <TableHead className="text-[#0D4F97] font-semibold px-4 sm:px-6 text-center">
+                          Frequência
+                        </TableHead>
+
+                      </TableRow>
+                    </TableHeader>
+
+                    <TableBody className="text-gray-600">
+                      {historicoTurmas.map((item, index) => (
+                        <TableRow key={`${item.ano}-${item.turno}-${item.tipo ?? ""}-${index}`}>
+
+                          <TableCell className="font-medium text-gray-900 truncate px-4 sm:px-6">
+                            {item.tipo?.trim() ? item.tipo : "—"}
+                          </TableCell>
+
+                          <TableCell className="truncate px-4 sm:px-6">
+                            {item.ano}
+                          </TableCell>
+
+                          <TableCell className="truncate px-4 sm:px-6">
+                            {item.turno}
+                          </TableCell>
+
+                          <TableCell className="px-4 sm:px-6">
+                            <span
+                              className={
+                                item.turmaAtual
+                                  ? "inline-flex rounded-full bg-emerald-100 px-2.5 py-0.5 text-xs font-medium text-emerald-800"
+                                  : "inline-flex rounded-full bg-slate-100 px-2.5 py-0.5 text-xs font-medium text-slate-700"
+                              }
+                            >
+                              {item.turmaAtual ? "Turma atual" : "Turma anterior"}
+                            </span>
+                          </TableCell>
+
+                          <TableCell className="px-4 sm:px-6 text-center">
+                            <div className="flex justify-center">
+                              <Eye
+                                className="h-5 w-5 cursor-pointer hover:text-[#0D4F97] transition-colors"
+                                onClick={() => handleAbrirHistoricoTurma(item)}
+                              />
+                            </div>
+                          </TableCell>
+
+                        </TableRow>
+                      ))}
+                    </TableBody>
+
+                  </Table>
+                </div>
+              )}
+            </div>
+
           </div>
 
           </CardContent>
@@ -515,6 +672,15 @@ export default function DetalhesDoAluno({ params }: { params: Promise<{ id: stri
           relatorio={selectedRelatorio}
           alunoNome={alunoData.nome}
           alunoDataNascimento={alunoData.dataNascimento}
+        />
+
+        <ModalHistoricoFrequencia
+          isOpen={isHistoricoOpen}
+          onClose={() => setIsHistoricoOpen(false)}
+          alunoNome={alunoData.nome}
+          historico={historicoAluno}
+          loading={loadingHistorico}
+          turma={turmaSelecionada}
         />
       </div>
     </div>

--- a/app/src/components/frequencia/ModalHistoricoFrequencia.tsx
+++ b/app/src/components/frequencia/ModalHistoricoFrequencia.tsx
@@ -31,13 +31,18 @@ export default function ModalHistoricoFrequencia({
     <Dialog open={isOpen} onOpenChange={onClose}>
       <DialogContent className="max-w-[95vw] sm:max-w-xl w-full pt-10 sm:pt-6">
         <DialogHeader>
-          <DialogTitle>
-            Histórico de Frequência - {alunoNome || ""}
-          </DialogTitle>
-          <DialogDescription>
-            Registros individuais de presença do aluno.
-          </DialogDescription>
-        </DialogHeader>
+  <DialogTitle>
+    Histórico de Frequência - {alunoNome || ""}
+    {turma && (
+      <span className="block text-sm font-normal text-gray-500 mt-1">
+        Turma: {turma.tipo || "—"} - {turma.ano} ({turma.turno})
+      </span>
+    )}
+  </DialogTitle>
+  <DialogDescription>
+    Registros individuais de presença do aluno.
+  </DialogDescription>
+</DialogHeader>
 
         {loading ? (
           <div className="py-6 text-center text-[#0D4F97]">

--- a/app/src/components/frequencia/ModalHistoricoFrequencia.tsx
+++ b/app/src/components/frequencia/ModalHistoricoFrequencia.tsx
@@ -1,0 +1,85 @@
+'use client';
+
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+  DialogFooter
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+
+interface Props {
+  isOpen: boolean;
+  onClose: () => void;
+  alunoNome: string;
+  historico: any[];
+  loading: boolean;
+  turma?: any;
+}
+
+export default function ModalHistoricoFrequencia({
+  isOpen,
+  onClose,
+  alunoNome,
+  historico,
+  loading,
+  turma
+}: Props) {
+  return (
+    <Dialog open={isOpen} onOpenChange={onClose}>
+      <DialogContent className="max-w-[95vw] sm:max-w-xl w-full pt-10 sm:pt-6">
+        <DialogHeader>
+          <DialogTitle>
+            Histórico de Frequência - {alunoNome || ""}
+          </DialogTitle>
+          <DialogDescription>
+            Registros individuais de presença do aluno.
+          </DialogDescription>
+        </DialogHeader>
+
+        {loading ? (
+          <div className="py-6 text-center text-[#0D4F97]">
+            Carregando histórico...
+          </div>
+        ) : historico.length === 0 ? (
+          <div className="py-6 text-center text-[#222222]">
+            Nenhum registro encontrado.
+          </div>
+        ) : (
+          <div className="max-h-80 overflow-y-auto mt-4 space-y-2">
+            {historico.map((item, index) => (
+              <div
+                key={index}
+                className="flex items-center justify-between border-b py-2"
+              >
+                <div>
+                  <p className="font-medium text-[#0D4F97]">{item.data}</p>
+                  <p className="text-sm text-[#222222]">
+                    {item.descricao || "Sem descrição"}
+                  </p>
+                </div>
+                <span
+                  className={`px-3 py-1 rounded-full text-xs font-semibold ${
+                    item.status === "Presente"
+                      ? "bg-green-100 text-green-700"
+                      : "bg-red-100 text-red-700"
+                  }`}
+                >
+                  {item.status}
+                </span>
+              </div>
+            ))}
+          </div>
+        )}
+
+        <DialogFooter className="mt-4">
+          <Button variant="outline" onClick={onClose}>
+            Fechar
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/app/src/components/turmas/DetalhesTurma.tsx
+++ b/app/src/components/turmas/DetalhesTurma.tsx
@@ -2,6 +2,7 @@
 
 import { ArrowLeft, Clock, Calendar, Users, Briefcase, Edit, Power, AlertTriangle } from "lucide-react";
 import { Button } from "@/components/ui/button";
+import ModalHistoricoFrequencia from "@/components/frequencia/ModalHistoricoFrequencia";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import {
     Dialog,
@@ -661,65 +662,15 @@ export function DetalhesTurma({
                             </DialogContent>
                         </Dialog>
 
-                        <Dialog open={isHistoricoOpen} onOpenChange={setIsHistoricoOpen}>
-                            <DialogContent className="max-w-[95vw] sm:max-w-xl w-full">
-                                <DialogHeader>
-                                    <DialogTitle>
-                                        Histórico de Frequência - {alunoSelecionado?.nome || ""}
-                                    </DialogTitle>
-                                    <DialogDescription>
-                                        Registros individuais de presença do aluno na turma.
-                                    </DialogDescription>
-                                </DialogHeader>
-
-                                {loadingHistorico ? (
-                                    <div className="py-6 text-center text-[#0D4F97]">
-                                        Carregando histórico...
-                                    </div>
-                                ) : historicoAluno.length === 0 ? (
-                                    <div className="py-6 text-center text-[#222222]">
-                                        Nenhum registro de frequência encontrado para este aluno.
-                                    </div>
-                                ) : (
-                                    <div className="max-h-80 overflow-y-auto mt-4 space-y-2">
-                                        {historicoAluno.map((item, index) => (
-                                            <div
-                                                key={index}
-                                                className="flex items-center justify-between border-b border-[#E2E8F0] py-2"
-                                            >
-                                                <div>
-                                                    <p className="font-medium text-[#0D4F97]">{item.data}</p>
-                                                    <p className="text-sm text-[#222222]">
-                                                        {item.descricao || "Sem descrição"}
-                                                    </p>
-                                                </div>
-                                                <div className="text-right">
-                                                    <span
-                                                        className={`px-3 py-1 rounded-full text-xs font-semibold ${item.status === "Presente"
-                                                                ? "bg-green-100 text-green-700"
-                                                                : "bg-red-100 text-red-700"
-                                                            }`}
-                                                    >
-                                                        {item.status}
-                                                    </span>
-                                                </div>
-                                            </div>
-                                        ))}
-                                    </div>
-                                )}
-
-                                <DialogFooter className="mt-4">
-                                    <Button variant="outline" 
-                                    onClick={() => setIsHistoricoOpen(false)}
-                                    >
-                                        Fechar
-                                    </Button>
-                                </DialogFooter>
-                            </DialogContent>
-                        </Dialog>
-
                     </CardContent>
                 </Card>
+                <ModalHistoricoFrequencia
+                    isOpen={isHistoricoOpen}
+                    onClose={() => setIsHistoricoOpen(false)}
+                    alunoNome={alunoSelecionado?.nome || ""}
+                    historico={historicoAluno}
+                    loading={loadingHistorico}
+                />
             </div>
         </div>
     );

--- a/app/src/services/AlunoService.js
+++ b/app/src/services/AlunoService.js
@@ -42,3 +42,13 @@ export const buscarAvaliacoesPorAlunoId = async (id) => {
         throw error;
     }
 };
+
+export const buscarHistoricoTurmasPorAlunoId = async (id) => {
+    try {
+        const response = await api.get(`/alunos/${id}/turmas/historico`);
+        return response.data;
+    } catch (error) {
+        console.error(`Erro ao buscar histórico de turmas do aluno ${id}:`, error);
+        throw error;
+    }
+};


### PR DESCRIPTION
# O que mudou?

Implementação da visualização do histórico de turmas do aluno na tela de detalhes, incluindo integração com o backend para buscar os dados e exibição em tabela com opção de visualizar o histórico de frequência por turma.

## Tarefas Relacionadas

* Issue: #299 
* Outras dependências: {pr_link}

## Mudanças Realizadas

* Criação do endpoint no backend para retornar o histórico de turmas do aluno
* Implementação do DTO `AlunoTurmaHistoricoResponseDTO` e ajustes no service/repository
* Integração do frontend com a API para carregar o histórico de turmas
* Exibição do histórico de turmas na tela de detalhes do aluno
* Implementação do modal de histórico de frequência por turma
* Integração com serviço de frequência para buscar dados por turma e aluno

## Evidências

Inclua imagens, vídeos, prints de logs, ou qualquer evidência que comprove que a funcionalidade está funcionando conforme o esperado.
![tela1](https://github.com/user-attachments/assets/b0e43614-3ddd-49d7-befc-8527af2743fd)
![tela2](https://github.com/user-attachments/assets/99c0b2a8-f2ed-443c-91ca-64df3d9803d1)
![tela3](https://github.com/user-attachments/assets/97e5ade2-3961-4055-a428-2d75da4a9885)
![tela4](https://github.com/user-attachments/assets/f8553bd4-e905-4b0f-a9d2-5824bf865d04)
![tela5](https://github.com/user-attachments/assets/4c339449-5596-4c61-a157-c4f4bc293249)

Closes #299 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Display student class history on the student details page with class type, year, shift, and current status.
  * New API endpoint to fetch a student's complete class history.
  * Modal for viewing attendance history/details within a selected class.

* **Refactor**
  * Extracted attendance-history modal into a reusable component used across pages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->