### PR TITLE
[BUG] Corrigir sobreposição de colunas nas tabelas de relatórios e av…

### DIFF
--- a/app/src/app/admin/alunos/detalhes/[id]/page.tsx
+++ b/app/src/app/admin/alunos/detalhes/[id]/page.tsx
@@ -275,8 +275,7 @@ export default function DetalhesDoAluno({ params }: { params: Promise<{ id: stri
 
               ) : (
                 <div className="overflow-x-auto max-h-80 overflow-y-auto border-2 border-[#B2D7EC] rounded-lg">
-
-                  <Table className="w-full table-fixed">
+                  <Table className="w-full table-fixed min-w-[860px]">
                       {/* Ordem das colunas: Data, Professor, Turma, Descrição, Ações*/}
                     <colgroup>
                       <col style={{ width: '130px' }} /> 
@@ -375,8 +374,7 @@ export default function DetalhesDoAluno({ params }: { params: Promise<{ id: stri
 
             ) : (
               <div className="overflow-x-auto max-h-80 overflow-y-auto border-2 border-[#B2D7EC] rounded-lg">
-
-                <Table className="w-full table-fixed">
+                <Table className="w-full table-fixed min-w-[1440px]">
                   {/* Ordem das colunas: Data, Professor, Turma, Atividades, Habilidades, Estratégias, Recursos, Ações*/}
                   <colgroup>
                     <col style={{ width: '130px' }} /> 

--- a/app/src/app/admin/alunos/detalhes/[id]/page.tsx
+++ b/app/src/app/admin/alunos/detalhes/[id]/page.tsx
@@ -336,10 +336,15 @@ export default function DetalhesDoAluno({ params }: { params: Promise<{ id: stri
 
                           <TableCell className="sticky right-0 z-10 bg-white group-hover:bg-[#B2D7EC]/10 text-center shadow-[-4px_0_8px_rgba(0,0,0,0.05)]">
                             <div className="flex items-center justify-center h-full">
-                              <Eye
-                                className="h-5 w-5 cursor-pointer hover:text-[#0D4F97] transition-colors"
+                              <button
+                                type="button"
+                                className="cursor-pointer hover:text-[#0D4F97] transition-colors"
                                 onClick={() => setSelectedAvaliacao(avaliacao)}
-                              />
+                                aria-label="Visualizar avaliação"
+                                title="Visualizar avaliação"
+                              >
+                                <Eye className="h-5 w-5" />
+                              </button>
                             </div>
                           </TableCell>
 
@@ -480,10 +485,15 @@ export default function DetalhesDoAluno({ params }: { params: Promise<{ id: stri
 
                         <TableCell className="sticky right-0 z-10 bg-white group-hover:bg-[#B2D7EC]/10 text-center shadow-[-4px_0_8px_rgba(0,0,0,0.05)]">
                           <div className="flex items-center justify-center h-full">
-                            <Eye
-                              className="h-5 w-5 cursor-pointer hover:text-[#0D4F97] transition-colors"
-                              onClick={() => setSelectedRelatorio(relatorio)}
-                            />
+                              <button
+                                type="button"
+                                className="cursor-pointer hover:text-[#0D4F97] transition-colors"
+                                onClick={() => setSelectedRelatorio(relatorio)}
+                                aria-label="Visualizar relatório"
+                                title="Visualizar relatório"
+                              >
+                                <Eye className="h-5 w-5" />
+                              </button>
                           </div>
                         </TableCell>
 

--- a/app/src/app/professor/alunos/[alunoId]/avaliacoes/page.tsx
+++ b/app/src/app/professor/alunos/[alunoId]/avaliacoes/page.tsx
@@ -242,18 +242,22 @@ export default function AvaliacoesAlunoPage() {
                             <Button 
                               variant="ghost" 
                               size="icon" 
-                          onClick={() => handleOpenEditarDialog(av)} 
-                          >
-                          <Edit className="h-5 w-5" />
-                        </Button>
-                        <Button 
-                          variant="ghost" 
-                          size="icon" 
-                          onClick={() => handleOpenExcluirDialog(av)} 
-                          >
-                          <Trash2 className="h-5 w-5" />
-                        </Button>
-                      </div>
+                              aria-label="Editar avaliação"
+                              title="Editar avaliação"
+                              onClick={() => handleOpenEditarDialog(av)} 
+                            >
+                              <Edit className="h-5 w-5" />
+                            </Button>
+                            <Button 
+                              variant="ghost" 
+                              size="icon" 
+                              aria-label="Excluir avaliação"
+                              title="Excluir avaliação"
+                              onClick={() => handleOpenExcluirDialog(av)} 
+                            >
+                              <Trash2 className="h-5 w-5" />
+                            </Button>
+                          </div>
                     </div>
                   ))}
                 </div>

--- a/app/src/app/professor/alunos/[alunoId]/avaliacoes/page.tsx
+++ b/app/src/app/professor/alunos/[alunoId]/avaliacoes/page.tsx
@@ -211,13 +211,14 @@ export default function AvaliacoesAlunoPage() {
 
           {/* Lista de Avaliações */}
           <Card className="rounded-xl border-2 border-[#B2D7EC] shadow-md">
-            <CardContent className="p-0">
-              {/* Header da Tabela */}
-              <div className="hidden border-b-2 border-[#B2D7EC] bg-[#B2D7EC]/20 md:grid md:grid-cols-12 md:gap-4 md:p-4">
-                <div className="col-span-2 text-[#0D4F97] font-semibold">Data</div>
-                <div className="col-span-8 text-[#0D4F97] font-semibold">Descrição</div>
-                <div className="col-span-2 text-center text-[#0D4F97] font-semibold">Ações</div>
-              </div>
+            <CardContent className="p-0 overflow-x-auto">
+              <div className="w-full md:min-w-[800px]">
+                {/* Header da Tabela */}
+                <div className="hidden border-b-2 border-[#B2D7EC] bg-[#B2D7EC]/20 md:grid md:grid-cols-12 md:gap-4 md:p-4">
+                  <div className="col-span-2 text-[#0D4F97] font-semibold">Data</div>
+                  <div className="col-span-8 text-[#0D4F97] font-semibold">Descrição</div>
+                  <div className="col-span-2 text-center text-[#0D4F97] font-semibold">Ações</div>
+                </div>
 
                 {loading ? (
                   <div className="p-8 text-center flex justify-center items-center">
@@ -226,14 +227,21 @@ export default function AvaliacoesAlunoPage() {
                 ) : avaliacoes.length === 0 ? (
                   <div className="p-8 text-center text-gray-500">Nenhuma avaliação encontrada.</div>
                 ) : (
-                  avaliacoes.map((av) => (
-                    <div key={av.id} className="grid grid-cols-1 md:grid-cols-12 gap-4 p-4 border-b border-[#B2D7EC] items-center hover:bg-gray-50">
-                      <div className="md:col-span-2 font-medium">{formatarData(av.dataAvaliacao)}</div>
-                      <div className="md:col-span-8 text-sm text-gray-700">{av.descricao}</div>
-                      <div className="md:col-span-2 flex justify-center gap-2">
-                        <Button 
-                          variant="ghost" 
-                          size="icon" 
+                  <div className="w-full">
+                    {avaliacoes.map((av) => (
+                        <div key={av.id} className="grid grid-cols-1 md:grid-cols-12 gap-4 p-4 border-b border-[#B2D7EC] items-center hover:bg-gray-50">
+                          <div className="col-span-1 md:col-span-2">
+                            <p className="text-[#0D4F97] md:hidden font-semibold">Data:</p>
+                            <p className="font-medium min-w-0 break-words">{formatarData(av.dataAvaliacao)}</p>
+                          </div>
+                          <div className="col-span-1 md:col-span-8">
+                            <p className="text-[#0D4F97] md:hidden font-semibold">Descrição:</p>
+                            <p className="text-sm text-gray-700 min-w-0 break-words">{av.descricao}</p>
+                          </div>
+                          <div className="col-span-1 md:col-span-2 flex justify-center gap-2">
+                            <Button 
+                              variant="ghost" 
+                              size="icon" 
                           onClick={() => handleOpenEditarDialog(av)} 
                           >
                           <Edit className="h-5 w-5" />
@@ -247,9 +255,11 @@ export default function AvaliacoesAlunoPage() {
                         </Button>
                       </div>
                     </div>
-                  ))
-                )}
-              </CardContent>
+                  ))}
+                </div>
+              )}
+              </div>
+            </CardContent>
             </Card>
 
             {/* Dialog Adicionar/Editar */}

--- a/app/src/app/professor/alunos/[alunoId]/relatorios/page.tsx
+++ b/app/src/app/professor/alunos/[alunoId]/relatorios/page.tsx
@@ -199,59 +199,60 @@ export default function RelatoriosAlunoListaPage() {
 
             {/* TABELA / GRID */}
             <Card className="rounded-xl border-2 border-[#B2D7EC] shadow-md">
-              <CardContent className="p-0">
-                {/* Cabeçalho Desktop */}
-                <div className="hidden border-b-2 border-[#B2D7EC] bg-[#B2D7EC]/20 md:grid md:grid-cols-12 md:gap-4 md:p-4">
-                  <div className="col-span-2 text-[#0D4F97] font-semibold">Data</div>
-                  <div className="col-span-2 text-[#0D4F97] font-semibold">Atividades</div>
-                  <div className="col-span-2 text-[#0D4F97] font-semibold">Habilidades</div>
-                  <div className="col-span-2 text-[#0D4F97] font-semibold">Estratégias</div>
-                  <div className="col-span-2 text-[#0D4F97] font-semibold">Recursos</div>
-                  <div className="col-span-2 text-center text-[#0D4F97] font-semibold">Ações</div>
-                </div>
+              <CardContent className="p-0 overflow-x-auto">
+                <div className="min-w-[1000px] w-full">
+                  {/* Cabeçalho Desktop */}
+                  <div className="hidden border-b-2 border-[#B2D7EC] bg-[#B2D7EC]/20 md:grid md:grid-cols-12 md:gap-4 md:p-4">
+                    <div className="col-span-2 text-[#0D4F97] font-semibold">Data</div>
+                    <div className="col-span-2 text-[#0D4F97] font-semibold">Atividades</div>
+                    <div className="col-span-2 text-[#0D4F97] font-semibold">Habilidades</div>
+                    <div className="col-span-2 text-[#0D4F97] font-semibold">Estratégias</div>
+                    <div className="col-span-2 text-[#0D4F97] font-semibold">Recursos</div>
+                    <div className="col-span-2 text-center text-[#0D4F97] font-semibold">Ações</div>
+                  </div>
 
-                {/* Lista de Relatórios */}
-                <div className="w-full">
-                  {relatorios.length === 0 ? (
-                    <div className="p-8 text-center text-gray-500">
-                      Nenhum relatório encontrado.
-                    </div>
-                  ) : (
-                    relatorios.map((rel) => (
-                      <div
-                        key={rel.id}
-                        className="grid grid-cols-1 md:grid-cols-12 gap-4 p-4 border-b border-[#B2D7EC] items-center hover:bg-gray-50"
-                      >
-                        <div className="col-span-1 md:col-span-2">
-                          <p className="text-[#0D4F97] md:hidden font-semibold">Data:</p>
-                          <p className="font-medium">
-                            {rel.createdAt
-                              ? format(new Date(rel.createdAt), "dd/MM/yyyy")
-                              : "---"}
-                          </p>
-                        </div>
+                  {/* Lista de Relatórios */}
+                  <div className="w-full">
+                    {relatorios.length === 0 ? (
+                      <div className="p-8 text-center text-gray-500">
+                        Nenhum relatório encontrado.
+                      </div>
+                    ) : (
+                      relatorios.map((rel) => (
+                        <div
+                          key={rel.id}
+                          className="grid grid-cols-1 md:grid-cols-12 gap-4 p-4 border-b border-[#B2D7EC] items-center hover:bg-gray-50"
+                        >
+                          <div className="col-span-1 md:col-span-2">
+                            <p className="text-[#0D4F97] md:hidden font-semibold">Data:</p>
+                            <p className="font-medium min-w-0 break-words">
+                              {rel.createdAt
+                                ? format(new Date(rel.createdAt), "dd/MM/yyyy")
+                                : "---"}
+                            </p>
+                          </div>
 
-                        <div className="col-span-1 md:col-span-2">
-                          <p className="text-[#0D4F97] md:hidden font-semibold">Atividades:</p>
-                          <p className="text-sm text-gray-700 line-clamp-3">{rel.atividades}</p>
-                        </div>
+                          <div className="col-span-1 md:col-span-2">
+                            <p className="text-[#0D4F97] md:hidden font-semibold">Atividades:</p>
+                            <p className="text-sm text-gray-700 line-clamp-3 min-w-0 break-words">{rel.atividades}</p>
+                          </div>
 
-                        <div className="col-span-1 md:col-span-2">
-                          <p className="text-[#0D4F97] md:hidden font-semibold">Habilidades:</p>
-                          <p className="text-sm text-gray-700 line-clamp-3">{rel.habilidades}</p>
-                        </div>
+                          <div className="col-span-1 md:col-span-2">
+                            <p className="text-[#0D4F97] md:hidden font-semibold">Habilidades:</p>
+                            <p className="text-sm text-gray-700 line-clamp-3 min-w-0 break-words">{rel.habilidades}</p>
+                          </div>
 
-                        <div className="col-span-1 md:col-span-2">
-                          <p className="text-[#0D4F97] md:hidden font-semibold">Estratégias:</p>
-                          <p className="text-sm text-gray-700 line-clamp-3">{rel.estrategias}</p>
-                        </div>
+                          <div className="col-span-1 md:col-span-2">
+                            <p className="text-[#0D4F97] md:hidden font-semibold">Estratégias:</p>
+                            <p className="text-sm text-gray-700 line-clamp-3 min-w-0 break-words">{rel.estrategias}</p>
+                          </div>
 
-                        <div className="col-span-1 md:col-span-2">
-                          <p className="text-[#0D4F97] md:hidden font-semibold">Recursos:</p>
-                          <p className="text-sm text-gray-700 line-clamp-3">{rel.recursos}</p>
-                        </div>
+                          <div className="col-span-1 md:col-span-2">
+                            <p className="text-[#0D4F97] md:hidden font-semibold">Recursos:</p>
+                            <p className="text-sm text-gray-700 line-clamp-3 min-w-0 break-words">{rel.recursos}</p>
+                          </div>
 
-                        <div className="col-span-1 md:col-span-2 flex justify-center gap-2">
+                          <div className="col-span-1 md:col-span-2 flex md:justify-center gap-2">
                           <Button
                             onClick={() => {
                               setRelatorioSelecionado(rel);
@@ -274,8 +275,9 @@ export default function RelatoriosAlunoListaPage() {
                           </Button>
                         </div>
                       </div>
-                    ))
-                  )}
+                      ))
+                    )}
+                  </div>
                 </div>
               </CardContent>
             </Card>

--- a/app/src/app/professor/alunos/[alunoId]/relatorios/page.tsx
+++ b/app/src/app/professor/alunos/[alunoId]/relatorios/page.tsx
@@ -253,27 +253,31 @@ export default function RelatoriosAlunoListaPage() {
                           </div>
 
                           <div className="col-span-1 md:col-span-2 flex md:justify-center gap-2">
-                          <Button
-                            onClick={() => {
-                              setRelatorioSelecionado(rel);
-                              setIsModalRelatorioOpen(true);
-                            }}
-                            variant="ghost"
-                            size="icon"
-                          >
-                            <Eye className="h-5 w-5" />
-                          </Button>
-                          <Button
-                            onClick={() => {
-                              setRelatorioExcluindo(rel);
-                              setIsExcluirDialogOpen(true);
-                            }}
-                            variant="ghost"
-                            size="icon"
-                          >
-                            <Trash2 className="h-5 w-5" />
-                          </Button>
-                        </div>
+                            <Button
+                              onClick={() => {
+                                setRelatorioSelecionado(rel);
+                                setIsModalRelatorioOpen(true);
+                              }}
+                              variant="ghost"
+                              size="icon"
+                              aria-label="Visualizar relatório"
+                              title="Visualizar relatório"
+                            >
+                              <Eye className="h-5 w-5" />
+                            </Button>
+                            <Button
+                              onClick={() => {
+                                setRelatorioExcluindo(rel);
+                                setIsExcluirDialogOpen(true);
+                              }}
+                              variant="ghost"
+                              size="icon"
+                              aria-label="Excluir relatório"
+                              title="Excluir relatório"
+                            >
+                              <Trash2 className="h-5 w-5" />
+                            </Button>
+                          </div>
                       </div>
                       ))
                     )}

--- a/app/src/app/professor/turmas/[turmaId]/alunos/page.tsx
+++ b/app/src/app/professor/turmas/[turmaId]/alunos/page.tsx
@@ -243,7 +243,7 @@ export default function TurmaDetalhesPage() {
           </Card>
 
           {viewMode === "grid" && (
-            <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4 mb-6">
+            <div className="grid grid-cols-1 lg:grid-cols-2 xl:grid-cols-3 gap-4 mb-6">
               {filteredAlunos.map((aluno: any) => (
                 <Card
                   key={aluno.id}
@@ -261,13 +261,15 @@ export default function TurmaDetalhesPage() {
                     </div>
 
                     <div className="space-y-3 mb-4">
-                      <div className="flex items-center justify-between">
+                      <div className="flex flex-wrap items-center justify-between gap-2 bg-green-50/50 p-2 rounded border border-green-100">
                         <div className="flex items-center gap-2">
-                          <BarChart3 className="h-4 w-4 text-green-600" />
-                          <span className="text-gray-700">Última Avaliação:</span>
+                          <BarChart3 className="h-4 w-4 text-green-600 shrink-0" />
+                          <span className="text-gray-700 text-sm font-medium">Última Avaliação:</span>
                         </div>
-                        <div className="text-right">
-                          <div className="font-bold text-green-600">{aluno.ultimaAvaliacao}</div>
+                        <div className="text-right flex-1 min-w-0">
+                          <div className="font-bold text-green-600 truncate" title={aluno.ultimaAvaliacao}>
+                            {aluno.ultimaAvaliacao}
+                          </div>
                         </div>
                       </div>
                     </div>

--- a/app/src/app/professor/turmas/page.tsx
+++ b/app/src/app/professor/turmas/page.tsx
@@ -121,7 +121,7 @@ export default function TurmasPage() {
 
                   <div className="mb-4 flex flex-wrap items-start justify-between gap-3">
 
-                    <h3 className="text-[#0D4F97] font-bold text-lg md:text-xl pr-2 flex-1 min-w-0 break-words">
+                    <h3 className="text-[#0D4F97] font-bold text-lg md:text-xl pr-2 flex-1 min-w-0 break-normal">
                       {turma.nome}
                     </h3>
 
@@ -150,7 +150,7 @@ export default function TurmasPage() {
 
                   </div>
 
-                  <div className="flex flex-col sm:flex-row gap-3">
+                  <div className="flex flex-wrap gap-3">
 
                     <Button
                       onClick={(e) =>
@@ -160,10 +160,10 @@ export default function TurmasPage() {
                         )
                       }
                       variant="outline"
-                      className="h-10 flex-1 border-2 border-[#0D4F97] text-[#0D4F97] font-bold hover:bg-[#0D4F97] hover:text-white"
+                      className="h-10 flex-1 min-w-[130px] border-2 border-[#0D4F97] text-[#0D4F97] font-bold hover:bg-[#0D4F97] hover:text-white"
                     >
-                      <Users className="mr-2 h-4 w-4" />
-                      Ver Alunos
+                      <Users className="mr-2 h-4 w-4 flex-shrink-0" />
+                      <span>Ver Alunos</span>
                     </Button>
 
                     <Button
@@ -173,10 +173,10 @@ export default function TurmasPage() {
                           e
                         )
                       }
-                      className="h-10 flex-1 bg-[#0D4F97] text-white font-bold hover:bg-[#FFD000] hover:text-[#0D4F97]"
+                      className="h-10 flex-1 min-w-[130px] bg-[#0D4F97] text-white font-bold hover:bg-[#FFD000] hover:text-[#0D4F97]"
                     >
-                      <ClipboardCheck className="mr-2 h-4 w-4" />
-                      Frequência
+                      <ClipboardCheck className="mr-2 h-4 w-4 flex-shrink-0" />
+                      <span>Frequência</span>
                     </Button>
 
                   </div>

--- a/app/src/app/professor/turmas/page.tsx
+++ b/app/src/app/professor/turmas/page.tsx
@@ -107,7 +107,7 @@ export default function TurmasPage() {
           {turmas.length === 0 ? (
             <p className="text-center">Nenhuma turma ativa encontrada.</p>
           ) : (
-            <div className="grid grid-cols-1 gap-6 md:grid-cols-2">
+            <div className="grid grid-cols-1 gap-6 lg:grid-cols-2 xl:grid-cols-3">
 
               {turmas.map((turma: Turma) => (
 
@@ -119,13 +119,13 @@ export default function TurmasPage() {
                   }
                 >
 
-                  <div className="mb-4 flex items-center justify-between">
+                  <div className="mb-4 flex flex-wrap items-start justify-between gap-3">
 
-                    <h3 className="text-[#0D4F97] font-bold text-lg md:text-xl pr-2">
+                    <h3 className="text-[#0D4F97] font-bold text-lg md:text-xl pr-2 flex-1 min-w-0 break-words">
                       {turma.nome}
                     </h3>
 
-                    <span className="flex-shrink-0 rounded-full bg-[#B2D7EC] px-3 py-1 text-[#0D4F97] font-bold text-xs uppercase">
+                    <span className="flex-shrink-0 rounded-full bg-[#B2D7EC] px-3 py-1 text-[#0D4F97] font-bold text-xs uppercase mt-1">
                       {turma.totalAlunosAtivos ?? 0} ALUNOS
                     </span>
 
@@ -133,10 +133,12 @@ export default function TurmasPage() {
 
                   <div className="mb-6 space-y-2 text-[#222222] text-sm md:text-base">
 
-                    <p className="flex items-center gap-2">
-                      <Calendar className="h-4 w-4 text-[#0D4F97]/70" />
-                      <strong>Horário:</strong> {turma.horario}
-                    </p>
+                    <div className="flex items-start gap-2">
+                      <Calendar className="h-4 w-4 text-[#0D4F97]/70 mt-1 flex-shrink-0" />
+                      <p className="break-words min-w-0 flex-1">
+                        <strong>Horário:</strong> {turma.horario}
+                      </p>
+                    </div>
 
                     <p>
                       <strong>Turno:</strong> {turma.turno}

--- a/app/src/components/alunos/EstudanteCard.tsx
+++ b/app/src/components/alunos/EstudanteCard.tsx
@@ -24,12 +24,12 @@ export function EstudanteCard({
     return (
         <Card className="rounded-xl border-2 border-[#B2D7EC] shadow-md mb-6">
             <CardContent className="p-6">
-                <div className="flex flex-col gap-6 md:flex-row md:items-center md:justify-between">
-                    <div className="flex items-start gap-4 mt-4">
+                <div className="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between w-full">
+                    <div className="flex items-center gap-4 flex-1 min-w-0">
                         <div className="flex h-16 w-16 flex-shrink-0 items-center justify-center rounded-full bg-[#B2D7EC]/20">
                             <UserCircle className="h-10 w-10 text-[#0D4F97]" />
                         </div>
-                        <div>
+                        <div className="min-w-0 flex-1">
                             {loading ? (
                                 <div className="flex items-center gap-2">
                                     <Loader2 className="h-6 w-6 animate-spin text-[#0D4F97]" />
@@ -37,17 +37,21 @@ export function EstudanteCard({
                                 </div>
                             ) : (
                                 <>
-                                    <h2 className="text-[#0D4F97] text-xl font-bold">{nome}</h2>
-                                    <p className="text-[#222222]">
+                                    <h2 className="text-[#0D4F97] text-xl font-bold break-words">{nome}</h2>
+                                    <p className="text-[#222222] break-words">
                                         {turma}
                                         {turno && !turma.includes(turno) && ` - ${turno}`}
                                     </p>
-                                    {/* IDs removidos conforme solicitado */}
                                 </>
                             )}
                         </div>
                     </div>
-                    {action && <div className="mt-4 md:mt-0">{action}</div>}
+                    
+                    {action && (
+                        <div className="flex-shrink-0">
+                            {action}
+                        </div>
+                    )}
                 </div>
             </CardContent>
         </Card>


### PR DESCRIPTION
…aliações

# O que mudou?

Corrigir graves falhas de responsividade (sobreposição de colunas e textos espremidos) detectadas nas telas de Relatórios e Avaliações do Professor, bem como na listagem completa do painel Admin. O objetivo central foi garantir a acessibilidade e legibilidade total dos dados e botões de ação em resoluções com espaço limitado, notadamente no formato de um tablet (768px) com barra lateral.

## Tarefas Relacionadas

* Issue: {issue_link} #309 
* Outras dependências: {pr_link}

## Mudanças Realizadas

* Scroll Horizontal Nativo para Tabelas Grid (Professor): Nas telas avaliacoes/page.tsx e relatorios/page.tsx, ao invés das matrizes (CSS Grid) serem forçadas a se aglutinarem até sobrepor as informações na tela, instalamos encapsulamentos diretos com overflow-x-auto contendo min-w calculados estruturalmente (800px e 1000px respecticamente). Isso garante a integridade dos dados ativando a barra de rolagem.
* Scroll em Tabelas Shadcn (Admin): Correção do mesmo defeito de esmagamento na view admin/alunos/detalhes/[id]/page.tsx, adicionando um min-w na classe da raiz da <Table> baseando-se no limite do seu colgroup (860px e 1440px).
* Robustez contra Transbordamento de Palavras Longas: Adição preventiva de limites flex (min-w-0 break-words) para todas as linhas de layout e descrições, evintando que "textos de uma só linha" sem espaço danifiquem as margens globais de colunas.
* Correção da Interface do Card do Estudante: O nome longo no EstudanteCard entrava em conflito de margem lateral com o botão largo de chamada ("Adicionar Relatório") causando truncagem extrema (deformando o nome com ...). Alteramos o comportamento flexível transferindo as restrições de mesma linha vertical para lg:flex-row. Em tablets/mobile os blocos caem harmonicamente sobrepostos (flex-col), eliminando a contenção visual limitante. Limpeza de reticências fixas não responsivas completada no processo.
## Evidências
<img width="1319" height="968" alt="Captura de tela 2026-04-06 080548" src="https://github.com/user-attachments/assets/f8f6c312-3b01-4780-a6f0-9d4db8132c93" />
<img width="1273" height="962" alt="Captura de tela 2026-04-06 080702" src="https://github.com/user-attachments/assets/582ceeb7-8180-4c58-b022-d00bbf0355ff" />
<img width="1185" height="985" alt="Captura de tela 2026-04-06 082233" src="https://github.com/user-attachments/assets/3c98839b-82aa-476d-bbbd-5240858efb0f" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Improved responsiveness with horizontal scrolling support and adjusted grid breakpoints; added sensible minimum widths to table/list containers
  * Enhanced text handling (breaks, truncation, wrapping) and refined spacing/alignment for more consistent card and table layouts
  * Tweaked card content and metadata presentation for clearer, more stable displays
* **Accessibility**
  * Action icons converted to proper buttons with aria-labels and visible tooltips for better keyboard and assistive-tech support
<!-- end of auto-generated comment: release notes by coderabbit.ai -->