### PR TITLE
[BUG] Ajustar modal de relatórios para exibir turma correta e remover…

### DIFF
--- a/app/src/app/admin/alunos/detalhes/[id]/page.tsx
+++ b/app/src/app/admin/alunos/detalhes/[id]/page.tsx
@@ -515,6 +515,7 @@ export default function DetalhesDoAluno({ params }: { params: Promise<{ id: stri
           relatorio={selectedRelatorio}
           alunoNome={alunoData.nome}
           alunoDataNascimento={alunoData.dataNascimento}
+          alunoTurma={turmaCompleta}
         />
       </div>
     </div>

--- a/app/src/app/professor/alunos/[alunoId]/relatorios/page.tsx
+++ b/app/src/app/professor/alunos/[alunoId]/relatorios/page.tsx
@@ -293,6 +293,7 @@ export default function RelatoriosAlunoListaPage() {
           relatorio={relatorioSelecionado}
           alunoNome={alunoData?.nome}
           alunoDataNascimento={alunoData?.dataNascimento}
+          alunoTurma={turmaData?.nome || alunoData?.turma?.nome}
           onSalvar={handleSalvarRelatorio}
         />
       )}

--- a/app/src/components/ModalVisualizarEditarRelatorio.tsx
+++ b/app/src/components/ModalVisualizarEditarRelatorio.tsx
@@ -41,6 +41,7 @@ interface ModalVisualizarEditarRelatorioProps {
   relatorio: Relatorio | null;
   alunoNome?: string;
   alunoDataNascimento?: string;
+  alunoTurma?: string;
   onSalvar?: (relatorioAtualizado: Relatorio) => void;
 }
 
@@ -65,6 +66,7 @@ export default function ModalVisualizarEditarRelatorio({
   relatorio,
   alunoNome,
   alunoDataNascimento,
+  alunoTurma,
   onSalvar,
 }: ModalVisualizarEditarRelatorioProps) {
   const [isEditando, setIsEditando] = useState(false);
@@ -96,26 +98,26 @@ export default function ModalVisualizarEditarRelatorio({
             setDadosAlunoCompleto({
               nome: aluno.nome || alunoNome || relatorio.aluno || "Aluno",
               nascimento: aluno.dataNascimento || alunoDataNascimento || relatorio.aluno_nascimento || "—",
-              turma: aluno.turma?.nome || relatorio.turma || "Alfabetização 2025 - Manhã"
+              turma: aluno.turma?.nome || alunoTurma || relatorio.turma || "—"
             });
           } catch (error) {
             setDadosAlunoCompleto({
               nome: alunoNome || relatorio.aluno || "Aluno",
               nascimento: alunoDataNascimento || relatorio.aluno_nascimento || "—",
-              turma: relatorio.turma || "Alfabetização 2025 - Manhã"
+              turma: alunoTurma || relatorio.turma || "—"
             });
           }
         } else {
           setDadosAlunoCompleto({
             nome: alunoNome || relatorio.aluno || "Aluno",
             nascimento: alunoDataNascimento || relatorio.aluno_nascimento || "—",
-            turma: relatorio.turma || "Alfabetização 2025 - Manhã"
+            turma: alunoTurma || relatorio.turma || "—"
           });
         }
       }
     }
     carregarDadosAluno();
-  }, [isOpen, relatorio, alunoNome, alunoDataNascimento]);
+  }, [isOpen, relatorio, alunoNome, alunoDataNascimento, alunoTurma]);
 
   useEffect(() => {
     if (relatorio && isOpen) {
@@ -277,7 +279,6 @@ export default function ModalVisualizarEditarRelatorio({
               nome={dadosAlunoCompleto.nome}
               nascimento={dadosAlunoCompleto.nascimento}
               turma={dadosAlunoCompleto.turma}
-              ano={format(formData.data, "yyyy")}
             />
             <RelatorioIndividualConteudo
               atividades={formData.atividades}

--- a/app/src/components/alunos/ModalVisualizarRelatorio.tsx
+++ b/app/src/components/alunos/ModalVisualizarRelatorio.tsx
@@ -22,6 +22,7 @@ interface ModalVisualizarRelatorioProps {
   relatorio: any;
   alunoNome?: string;
   alunoDataNascimento?: string;
+  alunoTurma?: string;
 }
 
 export default function ModalVisualizarRelatorio({
@@ -30,6 +31,7 @@ export default function ModalVisualizarRelatorio({
   relatorio,
   alunoNome,
   alunoDataNascimento,
+  alunoTurma,
 }: ModalVisualizarRelatorioProps) {
   if (!relatorio) return null;
 
@@ -40,7 +42,7 @@ export default function ModalVisualizarRelatorio({
     : new Date();
 
   const nomeAluno = alunoNome || relatorio.aluno || "Aluno";
-  const turmaDisplay = relatorio.turma || "Alfabetização 2025 - Manhã";
+  const turmaDisplay = alunoTurma || relatorio.turmaNome || relatorio.turma || "—";
 
   return (
     <Dialog open={isOpen} onOpenChange={onClose}>
@@ -125,7 +127,6 @@ export default function ModalVisualizarRelatorio({
               nome={nomeAluno}
               nascimento={alunoDataNascimento || "—"}
               turma={turmaDisplay}
-              ano={format(dataRelatorio, "yyyy")}
             />
 
             <RelatorioIndividualConteudo

--- a/app/src/components/alunos/VisualizarRelatorioAdmin.tsx
+++ b/app/src/components/alunos/VisualizarRelatorioAdmin.tsx
@@ -149,7 +149,6 @@ export default function VisualizarRelatorioAdmin({
           nome={nomeAlunoFinal}
           nascimento={dataNascimentoFinal}
           turma={turmaNome}
-          ano={format(dataRelatorio, "yyyy")}
         />
 
         <RelatorioIndividualConteudo

--- a/app/src/components/impressao/DadosAlunoImpressao.tsx
+++ b/app/src/components/impressao/DadosAlunoImpressao.tsx
@@ -4,7 +4,6 @@ interface DadosAlunoImpressaoProps {
   nome: string;
   nascimento: string;
   turma: string;
-  ano: string;
 }
 
 export default function DadosAlunoImpressao({
@@ -13,7 +12,6 @@ export default function DadosAlunoImpressao({
   nome,
   nascimento,
   turma,
-  ano,
 }: DadosAlunoImpressaoProps) {
   return (
     <section className="impressao-dados">
@@ -31,9 +29,6 @@ export default function DadosAlunoImpressao({
 
       <p>
         <strong>TURMA:</strong> {turma}
-        <span style={{ marginLeft: "80px" }}>
-          <strong>ANO:</strong> {ano}
-        </span>
       </p>
     </section>
   );

--- a/app/src/components/impressao/DadosAlunoImpressao.tsx
+++ b/app/src/components/impressao/DadosAlunoImpressao.tsx
@@ -1,3 +1,5 @@
+import { format } from "date-fns";
+
 interface DadosAlunoImpressaoProps {
   cidade: string;
   dataRelatorio: string;
@@ -13,6 +15,21 @@ export default function DadosAlunoImpressao({
   nascimento,
   turma,
 }: DadosAlunoImpressaoProps) {
+
+  const formatarNascimento = (data: string) => {
+    if (!data || data === "—") return "—";
+    if (data.includes("/")) return data;
+
+    try {
+      const date = new Date(data);
+      if (!isNaN(date.getTime())) {
+        return format(date, "dd/MM/yyyy");
+      }
+    } catch (e) {}
+
+    return data;
+  };
+
   return (
     <section className="impressao-dados">
       <p>
@@ -24,7 +41,7 @@ export default function DadosAlunoImpressao({
       </p>
 
       <p>
-        <strong>DATA DE NASCIMENTO:</strong> {nascimento}
+        <strong>DATA DE NASCIMENTO:</strong> {formatarNascimento(nascimento)}
       </p>
 
       <p>


### PR DESCRIPTION
… campo ano

# O que mudou?

Havia um comportamento inesperado onde o documento de Relatório Individual exibia a variável de turma com um valor predefinido (Fallback como "Alfabetização 2025 - Manhã") ao invés da verdadeira turma de pertencimento do aluno. Adicionalmente, havia um parâmetro intrusivo que imputava o preenchimento automático do "Ano" na folha sulfite, sendo redundante ao layout.

## Tarefas Relacionadas

* Issue: {issue_link} #316 
* Outras dependências: {pr_link}

## Mudanças Realizadas

* Injeção Dinâmica de Turma: Os modais de visualização (ModalVisualizarRelatorio e ModalVisualizarEditarRelatorio) agora recebem apropriadamente um novo parâmetro alunoTurma oriundo diretamente dos painéis que os invocam, substituindo a antiga string presa ao código pela turma perfeitamente verídica do estudante selecionado.
* Limpeza do Componente de Impressão: Removidas ativamente as declarações HTML e a manipulação do campo ano das interfaces estritas do DadosAlunoImpressao.tsx e seus dependentes (incluindo o visualizador admin), deixando o layout da folha de avaliação mais limpo, profissional e estritamente focado no conteúdo relevante.


## Evidências

<img width="669" height="861" alt="Captura de tela 2026-04-06 094133" src="https://github.com/user-attachments/assets/3417a9a2-4bf0-4a69-a6cb-9ac0d000dc9e" />
<img width="1907" height="992" alt="Captura de tela 2026-04-06 094200" src="https://github.com/user-attachments/assets/698701a5-430b-4788-971f-9e5a4bda0310" />
<img width="1894" height="983" alt="Captura de tela 2026-04-06 101216" src="https://github.com/user-attachments/assets/d785a2af-3fe0-41cd-9933-5da00d0c9632" />
<img width="799" height="883" alt="Captura de tela 2026-04-06 101240" src="https://github.com/user-attachments/assets/71bd4bc5-adef-4715-abad-ec1f90644adb" />
<img width="1365" height="987" alt="Captura de tela 2026-04-06 102247" src="https://github.com/user-attachments/assets/d36e57af-5b14-4b96-ba46-395cbb9c9fbf" />
<img width="1821" height="958" alt="Captura de tela 2026-04-17 200158" src="https://github.com/user-attachments/assets/dcd627d8-8007-4aa4-9bc0-5a996b11aa8a" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Ensured student class/grade is consistently shown in report view/edit modals with reliable fallbacks.
  * Improved handling so class info updates when source data changes.

* **Style**
  * Removed explicit year from printed report templates for a cleaner layout.
  * Normalized date-of-birth formatting in printed reports for consistent presentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->