### PR TITLE
[Bug] Corrigindo inconsistencia entre legenda e exibição no calendario de frequencia

### DIFF
--- a/app/src/app/professor/turmas/[turmaId]/frequencia/page.tsx
+++ b/app/src/app/professor/turmas/[turmaId]/frequencia/page.tsx
@@ -12,7 +12,7 @@ import { Textarea } from "@/components/ui/textarea";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import { Input } from "@/components/ui/input";
 import { toast } from "sonner";
-import { format, startOfDay } from "date-fns";
+import { format, startOfDay, parse } from "date-fns";
 import { ptBR } from "date-fns/locale";
 import { buscarTurmaPorId } from "@/services/TurmaService";
 import { 
@@ -20,7 +20,8 @@ import {
     getEstatisticasTurma, 
     contarAulasRealizadas, 
     getAlunosDaTurma, 
-    getChamadaPorTurmaEData 
+    getChamadaPorTurmaEData,
+    getDatasComChamada
 } from "@/services/ChamadaService";
 import { getAlunosComFrequencia } from "@/services/FrequenciaService";
 import ChamadaCalendar from "@/components/ChamadaCalendar";
@@ -192,6 +193,7 @@ function ChamadaContent({
     const [isSaving, setIsSaving] = useState(false);
     const [isEditing, setIsEditing] = useState(false);
     const [loadingChamada, setLoadingChamada] = useState(false);
+    const [savedDates, setSavedDates] = useState<Date[]>([]);
 
     const todayStart = startOfDay(new Date());
     const selectedDateStart = startOfDay(selectedDate);
@@ -204,6 +206,11 @@ function ChamadaContent({
             
             try {
                 setLoadingChamada(true);
+
+                const datasStr = await getDatasComChamada(turmaId);
+                const datesParsed = datasStr.map((d: string) => parse(d, "yyyy-MM-dd", new Date()));
+                setSavedDates(datesParsed);
+
                 const dataFormatada = format(selectedDate, "yyyy-MM-dd");
                 const chamadaExistente = await getChamadaPorTurmaEData(turmaId, dataFormatada);
                 
@@ -314,8 +321,6 @@ function ChamadaContent({
         const studentId = Number(aluno.id);
         return acc + ((attendance[studentId] ?? true) ? 1 : 0);
     }, 0);
-
-    const savedDates = [];
 
     return (
         <div className="space-y-6">

--- a/app/src/components/ChamadaCalendar.tsx
+++ b/app/src/components/ChamadaCalendar.tsx
@@ -62,6 +62,7 @@ export default function ChamadaCalendar({ selected, onSelect, savedDates = [] }:
         onSelect={onSelect}
         locale={ptBR}
         disabled={isDisabled}
+        modifiers={modifiers}
         modifiersClassNames={modifiersClassNames}
         month={currentMonth}
         onMonthChange={setCurrentMonth}
@@ -74,10 +75,10 @@ export default function ChamadaCalendar({ selected, onSelect, savedDates = [] }:
           row: "flex w-full justify-between mt-1",
           cell: "relative p-0 text-center flex items-center justify-center",
           day: "h-9 w-9 p-0 font-normal hover:bg-[#B2D7EC]/20 rounded-md transition-all flex items-center justify-center",
-          day_selected: "bg-[#0D4F97] text-white hover:bg-[#0D4F97] !opacity-100 z-10",
-          day_today: "border-2 border-[#0D4F97] text-[#0D4F97] font-black",
-          day_outside: "text-gray-300 opacity-20",
-          day_disabled: "text-gray-200 opacity-20 cursor-not-allowed",
+          selected: "bg-[#0D4F97] text-white hover:bg-[#0D4F97] !opacity-100 z-10",
+          today: "border-2 border-[#0D4F97] text-[#0D4F97] font-black",
+          outside: "text-gray-300 opacity-20",
+          disabled: "text-gray-200 opacity-20 cursor-not-allowed",
           
           caption: "flex justify-between items-center pt-1 mb-4",
           caption_label: "text-[#0D4F97] font-bold capitalize",

--- a/app/src/services/ChamadaService.js
+++ b/app/src/services/ChamadaService.js
@@ -132,3 +132,19 @@ export async function contarAulasRealizadas(turmaId) {
     const count = db.filter(r => r.turmaId == turmaId).length;
     return count;
 }
+
+export async function getDatasComChamada(turmaId) {
+    try {
+        const db = getMockDB();
+        const records = db.filter(r => r.turmaId == turmaId);
+        
+        // Em um cenário real tentaríamos buscar do backend as datas
+        // const response = await api.get(`/presencas/chamadas/turmas/${turmaId}/datas`);
+        // if (response?.data) return response.data;
+
+        return records.map(r => r.data);
+    } catch (error) {
+        console.error("ChamadaService Error (getDatasComChamada):", error);
+        return [];
+    }
+}


### PR DESCRIPTION
# O que mudou?

Agora o calendário na tela de frequencia apresenta a legenda corretamente com cores e informações  corretas.

## Tarefas Relacionadas

* Issue: #328 
* Outras dependências: {pr_link}

## Mudanças Realizadas

* Legenda e exibição estão corretas
* Datas com chamada feita ficam verde, dia selecionado fica azul e dia atual tem borda azul.

## Evidências

Inclua imagens, vídeos, prints de logs, ou qualquer evidência que comprove que a funcionalidade está funcionando conforme o esperado.
<img width="1280" height="662" alt="tela01" src="https://github.com/user-attachments/assets/56f3163e-763e-4227-b4b4-57196b26b749" />
<img width="1463" height="855" alt="tela02" src="https://github.com/user-attachments/assets/04ff7a97-b9fc-424c-b669-8cfad003ffe2" />
<img width="1361" height="849" alt="tela03" src="https://github.com/user-attachments/assets/84a10be2-a7ce-4371-ae02-771f3e7896ce" />
<img width="1687" height="871" alt="tela04" src="https://github.com/user-attachments/assets/afc3b1f6-9fa0-4a86-b6cf-1492967bddde" />

Closes #328 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The attendance calendar now dynamically loads and displays actual dates when attendance records exist for a class, replacing previously empty or hardcoded placeholders with real data.

* **Style**
  * Updated calendar styling for improved visual consistency when displaying selected, current, outside, and disabled dates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->