### PR TITLE
feat: configura MinIO e cria bucket 'professores' automaticamente

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -18,7 +18,7 @@ DATASOURCE_PASSWORD=sua_senha_aqui
 MINIO_URL=http://localhost:9000
 MINIO_ACCESS_KEY=apae_admin
 MINIO_SECRET_KEY=apae_secret123
-MINIO_BUCKET=apae-bucket
+MINIO_BUCKET=professores
 
 # Configurações / Credenciais do Admin
 ADMIN_EMAIL=admin@apae.com.br

--- a/README.md
+++ b/README.md
@@ -165,12 +165,23 @@ Navegue até a pasta da API:
 cd api
 ```
 
-#### 2.1 Suba o banco de dados com Docker
+#### 2.1 Suba o banco de dados e o MinIO com Docker
 
 ```bash
 docker compose up -d
 ```
 **O banco de dados estará disponível em `localhost:5432`**
+
+O `docker compose` também sobe o serviço **MinIO** (armazenamento de arquivos S3-compatível):
+
+| Recurso | URL / Valor |
+|---------|-------------|
+| **API S3** | `http://localhost:9000` |
+| **Console Web** | `http://localhost:9001` |
+| **Usuário padrão** | `apae_admin` |
+| **Senha padrão** | `apae_secret123` |
+
+> Ao iniciar o backend, o bucket `professores` é criado automaticamente caso ainda não exista. As credenciais e a URL do MinIO são lidas do arquivo `.env` (veja `.env.example`).
 
 #### 2.2 Compile o código (opcional)
 

--- a/api/src/main/java/com/apae/gestao/config/MinioBucketInitializer.java
+++ b/api/src/main/java/com/apae/gestao/config/MinioBucketInitializer.java
@@ -1,0 +1,48 @@
+package com.apae.gestao.config;
+
+import org.springframework.boot.ApplicationArguments;
+import org.springframework.boot.ApplicationRunner;
+import org.springframework.stereotype.Component;
+
+import io.minio.BucketExistsArgs;
+import io.minio.MakeBucketArgs;
+import io.minio.MinioClient;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class MinioBucketInitializer implements ApplicationRunner {
+
+    private final MinioClient minioClient;
+    private final MinioProperties properties;
+
+    @Override
+    public void run(ApplicationArguments args) {
+        String bucket = properties.getBucket();
+
+        if (bucket == null || bucket.isBlank()) {
+            log.warn("Nome do bucket MinIO nao configurado (minio.bucket). Pulando inicializacao.");
+            return;
+        }
+
+        try {
+            boolean exists = minioClient.bucketExists(
+                    BucketExistsArgs.builder().bucket(bucket).build()
+            );
+
+            if (exists) {
+                log.info("Bucket MinIO '{}' ja existe.", bucket);
+                return;
+            }
+
+            minioClient.makeBucket(
+                    MakeBucketArgs.builder().bucket(bucket).build()
+            );
+            log.info("Bucket MinIO '{}' criado com sucesso.", bucket);
+        } catch (Exception e) {
+            log.warn("Nao foi possivel verificar/criar o bucket MinIO '{}': {}", bucket, e.getMessage());
+        }
+    }
+}

--- a/api/src/main/java/com/apae/gestao/config/MinioConfig.java
+++ b/api/src/main/java/com/apae/gestao/config/MinioConfig.java
@@ -1,0 +1,18 @@
+package com.apae.gestao.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import io.minio.MinioClient;
+
+@Configuration
+public class MinioConfig {
+
+    @Bean
+    public MinioClient minioClient(MinioProperties properties) {
+        return MinioClient.builder()
+                .endpoint(properties.getUrl())
+                .credentials(properties.getAccessKey(), properties.getSecretKey())
+                .build();
+    }
+}

--- a/api/src/main/java/com/apae/gestao/config/MinioProperties.java
+++ b/api/src/main/java/com/apae/gestao/config/MinioProperties.java
@@ -1,0 +1,24 @@
+package com.apae.gestao.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Component
+@ConfigurationProperties(prefix = "minio")
+public class MinioProperties {
+
+    private String url;
+
+    private String accessKey;
+
+    private String secretKey;
+
+    private String bucket;
+
+    private boolean secure;
+}


### PR DESCRIPTION
# O que mudou?

Este PR configura o MinIO como serviço de armazenamento de arquivos do sistema e prepara a infraestrutura para futuras funcionalidades de upload de imagens (inicialmente para professores). A integração expõe o `MinioClient` como bean do Spring, externaliza as configurações via `.env` e garante que o bucket `professores` seja criado automaticamente ao subir o backend, evitando passos manuais e mantendo o ambiente de desenvolvimento pronto para uso.

## Tarefas Relacionadas

* Issue: https://github.com/orgs/IFPBEsp/projects/14/views/1?pane=issue&itemId=177349871&issue=IFPBEsp%7CAPAE-gestao-escolar%7C330

## Mudanças Realizadas

* Adicionada classe `MinioProperties` com `@ConfigurationProperties(prefix = "minio")` para tipar e externalizar as configurações (`url`, `accessKey`, `secretKey`, `bucket`, `secure`).
* Criada `MinioConfig` expondo o `MinioClient` como `@Bean`, habilitando injeção de dependência e atendendo o teste existente `MinioConnectionTest`.
* Implementado `MinioBucketInitializer` (`ApplicationRunner`) que, no startup, verifica e cria o bucket `professores` caso não exista, com log WARN em caso de falha (não derruba o boot em DEV).
* Atualizado `MINIO_BUCKET=professores` em `.env` e `.env.example`.
* Documentado no `README.md` o serviço MinIO (console em `http://localhost:9001`, credenciais default e criação automática do bucket).

## Evidências

<img width="1767" height="168" alt="image" src="https://github.com/user-attachments/assets/c461e4a0-fef0-4b1f-a19e-91ebf2b8408a" />
<img width="1920" height="999" alt="image" src="https://github.com/user-attachments/assets/0ad15c83-c07a-4331-865d-9ba0feea22e3" />




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * MinIO object storage integration with automatic creation of the default bucket on startup.

* **Documentation**
  * Quick Start updated: Docker compose startup, local S3 and web console endpoints, default credentials, and guidance that the default bucket is named "professores" and configured via the environment example.

* **Chores**
  * Default `.env.example` updated to set MINIO_BUCKET=professores.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->