### PR TITLE
[BUG] Corrigir listagem de alunos no admin e permitir filtro por status de vínculo em turma

### DIFF
--- a/api/src/main/java/com/apae/gestao/controller/AlunoController.java
+++ b/api/src/main/java/com/apae/gestao/controller/AlunoController.java
@@ -47,12 +47,12 @@ public class AlunoController {
     public ResponseEntity<Page<AlunoResumoDTO>> listarAlunosPorNome(
             @Parameter(example = "João", in = ParameterIn.QUERY)
             @RequestParam(value = "nome", required = false) String nome,
-
-            @PageableDefault(size = 12, sort = "nome")
+            @RequestParam(defaultValue = "false", required = false) Boolean apenasAtivos,
+            @PageableDefault(size = 30, sort = "nome")
             Pageable pageable
     ) {
         Page<AlunoResumoDTO> alunos =
-                alunoService.listarAlunosPorNome(nome, pageable);
+                alunoService.listarAlunosPorNome(nome,apenasAtivos, pageable);
 
         return ResponseEntity.ok(alunos);
     }

--- a/api/src/main/java/com/apae/gestao/repository/AlunoRepository.java
+++ b/api/src/main/java/com/apae/gestao/repository/AlunoRepository.java
@@ -36,6 +36,22 @@ public interface AlunoRepository extends JpaRepository<Aluno, Long> {
     """)
     Page<AlunoResumoDTO> listarAlunosResumido(Pageable pageable);
 
+    @Query(value = """
+        SELECT new com.apae.gestao.dto.aluno.AlunoResumoDTO(
+            a.id, a.nome, a.nomeResponsavel, t.nome, t.turno,
+            (SELECT CASE WHEN COUNT(p) = 0 THEN 0.0 ELSE SUM(CASE WHEN p.faltou = false THEN 1.0 ELSE 0.0 END) * 100.0 / COUNT(p) END 
+             FROM Presenca p WHERE p.aluno.id = a.id AND p.aula.turma.id = t.id),
+            (SELECT MAX(av.dataAvaliacao) FROM Avaliacao av WHERE av.aluno.id = a.id)
+        )
+        FROM Aluno a
+        JOIN a.turmaAlunos ta ON ta.isAlunoAtivo = true
+        JOIN ta.turma t
+        GROUP BY a.id, a.nome, a.nomeResponsavel, t.id, t.nome, t.turno, ta
+    """, countQuery = "SELECT COUNT(a) FROM Aluno a JOIN a.turmaAlunos ta ON ta.isAlunoAtivo = true")
+    Page<AlunoResumoDTO> listarAlunosAtivosResumido(Pageable pageable);
+
+
+
     @Query("""
         SELECT new com.apae.gestao.dto.aluno.AlunoResumoDTO(
             a.id,
@@ -58,6 +74,21 @@ public interface AlunoRepository extends JpaRepository<Aluno, Long> {
         GROUP BY a.id, a.nome, a.nomeResponsavel
     """)
     Page<AlunoResumoDTO> listarAlunosPorNomeResumido(String nome, Pageable pageable);
+
+    @Query(value = """
+        SELECT new com.apae.gestao.dto.aluno.AlunoResumoDTO(
+            a.id, a.nome, a.nomeResponsavel, t.nome, t.turno,
+            (SELECT CASE WHEN COUNT(p) = 0 THEN 0.0 ELSE SUM(CASE WHEN p.faltou = false THEN 1.0 ELSE 0.0 END) * 100.0 / COUNT(p) END 
+             FROM Presenca p WHERE p.aluno.id = a.id AND p.aula.turma.id = t.id),
+            (SELECT MAX(av.dataAvaliacao) FROM Avaliacao av WHERE av.aluno.id = a.id)
+        )
+        FROM Aluno a
+        JOIN a.turmaAlunos ta ON ta.isAlunoAtivo = true
+        JOIN ta.turma t
+        WHERE LOWER(a.nome) LIKE LOWER(CONCAT('%', :nome, '%'))
+        GROUP BY a.id, a.nome, a.nomeResponsavel, t.id, t.nome, t.turno, ta
+    """, countQuery = "SELECT COUNT(a) FROM Aluno a JOIN a.turmaAlunos ta ON ta.isAlunoAtivo = true WHERE LOWER(a.nome) LIKE LOWER(CONCAT('%', :nome, '%'))")
+    Page<AlunoResumoDTO> listarAlunosAtivosPorNomeResumido(String nome, Pageable pageable);
 
     @Query("""
         SELECT new com.apae.gestao.dto.aluno.AlunoFrequenciaResumoDTO(

--- a/api/src/main/java/com/apae/gestao/repository/AlunoRepository.java
+++ b/api/src/main/java/com/apae/gestao/repository/AlunoRepository.java
@@ -36,18 +36,29 @@ public interface AlunoRepository extends JpaRepository<Aluno, Long> {
     """)
     Page<AlunoResumoDTO> listarAlunosResumido(Pageable pageable);
 
-    @Query(value = """
-        SELECT new com.apae.gestao.dto.aluno.AlunoResumoDTO(
-            a.id, a.nome, a.nomeResponsavel, t.nome, t.turno,
-            (SELECT CASE WHEN COUNT(p) = 0 THEN 0.0 ELSE SUM(CASE WHEN p.faltou = false THEN 1.0 ELSE 0.0 END) * 100.0 / COUNT(p) END 
-             FROM Presenca p WHERE p.aluno.id = a.id AND p.aula.turma.id = t.id),
-            (SELECT MAX(av.dataAvaliacao) FROM Avaliacao av WHERE av.aluno.id = a.id)
-        )
-        FROM Aluno a
-        JOIN a.turmaAlunos ta ON ta.isAlunoAtivo = true
-        JOIN ta.turma t
-        GROUP BY a.id, a.nome, a.nomeResponsavel, t.id, t.nome, t.turno, ta
-    """, countQuery = "SELECT COUNT(a) FROM Aluno a JOIN a.turmaAlunos ta ON ta.isAlunoAtivo = true")
+    @Query(
+            value = """
+            SELECT new com.apae.gestao.dto.aluno.AlunoResumoDTO(
+                a.id,
+                a.nome,
+                a.nomeResponsavel,
+                MAX(t.nome),
+                MAX(t.turno),
+                CASE 
+                    WHEN COUNT(p) = 0 THEN 0
+                    ELSE SUM(CASE WHEN p.faltou = false THEN 1 ELSE 0 END) * 100.0 / COUNT(p)
+                END,
+                MAX(av.dataAvaliacao)
+            )
+            FROM Aluno a
+            JOIN a.turmaAlunos ta ON ta.isAlunoAtivo = true
+            JOIN ta.turma t
+            LEFT JOIN a.presencas p ON p.aula.turma.id = t.id
+            LEFT JOIN a.avaliacoes av
+            GROUP BY a.id, a.nome, a.nomeResponsavel
+        """,
+            countQuery = "SELECT COUNT(DISTINCT a) FROM Aluno a JOIN a.turmaAlunos ta ON ta.isAlunoAtivo = true"
+    )
     Page<AlunoResumoDTO> listarAlunosAtivosResumido(Pageable pageable);
 
 
@@ -75,19 +86,30 @@ public interface AlunoRepository extends JpaRepository<Aluno, Long> {
     """)
     Page<AlunoResumoDTO> listarAlunosPorNomeResumido(String nome, Pageable pageable);
 
-    @Query(value = """
-        SELECT new com.apae.gestao.dto.aluno.AlunoResumoDTO(
-            a.id, a.nome, a.nomeResponsavel, t.nome, t.turno,
-            (SELECT CASE WHEN COUNT(p) = 0 THEN 0.0 ELSE SUM(CASE WHEN p.faltou = false THEN 1.0 ELSE 0.0 END) * 100.0 / COUNT(p) END 
-             FROM Presenca p WHERE p.aluno.id = a.id AND p.aula.turma.id = t.id),
-            (SELECT MAX(av.dataAvaliacao) FROM Avaliacao av WHERE av.aluno.id = a.id)
-        )
-        FROM Aluno a
-        JOIN a.turmaAlunos ta ON ta.isAlunoAtivo = true
-        JOIN ta.turma t
-        WHERE LOWER(a.nome) LIKE LOWER(CONCAT('%', :nome, '%'))
-        GROUP BY a.id, a.nome, a.nomeResponsavel, t.id, t.nome, t.turno, ta
-    """, countQuery = "SELECT COUNT(a) FROM Aluno a JOIN a.turmaAlunos ta ON ta.isAlunoAtivo = true WHERE LOWER(a.nome) LIKE LOWER(CONCAT('%', :nome, '%'))")
+    @Query(
+            value = """
+            SELECT new com.apae.gestao.dto.aluno.AlunoResumoDTO(
+                a.id,
+                a.nome,
+                a.nomeResponsavel,
+                MAX(t.nome),
+                MAX(t.turno),
+                CASE 
+                    WHEN COUNT(p) = 0 THEN 0
+                    ELSE SUM(CASE WHEN p.faltou = false THEN 1 ELSE 0 END) * 100.0 / COUNT(p)
+                END,
+                MAX(av.dataAvaliacao)
+            )
+            FROM Aluno a
+            JOIN a.turmaAlunos ta ON ta.isAlunoAtivo = true
+            JOIN ta.turma t
+            LEFT JOIN a.presencas p ON p.aula.turma.id = t.id
+            LEFT JOIN a.avaliacoes av
+            WHERE LOWER(a.nome) LIKE LOWER(CONCAT('%', :nome, '%'))
+            GROUP BY a.id, a.nome, a.nomeResponsavel
+        """,
+            countQuery = "SELECT COUNT(DISTINCT a) FROM Aluno a JOIN a.turmaAlunos ta ON ta.isAlunoAtivo = true WHERE LOWER(a.nome) LIKE LOWER(CONCAT('%', :nome, '%'))"
+    )
     Page<AlunoResumoDTO> listarAlunosAtivosPorNomeResumido(String nome, Pageable pageable);
 
     @Query("""

--- a/api/src/main/java/com/apae/gestao/service/AlunoService.java
+++ b/api/src/main/java/com/apae/gestao/service/AlunoService.java
@@ -43,11 +43,18 @@ public class AlunoService {
     }
 
     @Transactional(readOnly = true)
-    public Page<AlunoResumoDTO> listarAlunosPorNome(String nome, Pageable pageable) {
-        Page<AlunoResumoDTO> page =
-                (nome == null || nome.isBlank())
-                        ? alunoRepository.listarAlunosResumido(pageable)
-                        : alunoRepository.listarAlunosPorNomeResumido(nome, pageable);
+    public Page<AlunoResumoDTO> listarAlunosPorNome(String nome,Boolean apenasAtivos, Pageable pageable) {
+        Page<AlunoResumoDTO> page;
+
+        if(Boolean.TRUE.equals(apenasAtivos)){
+            page = (nome == null || nome.isBlank())
+                    ? alunoRepository.listarAlunosAtivosResumido(pageable)
+                    : alunoRepository.listarAlunosAtivosPorNomeResumido(nome, pageable);
+        }else {
+            page = (nome == null || nome.isBlank())
+                    ? alunoRepository.listarAlunosResumido(pageable)
+                    : alunoRepository.listarAlunosPorNomeResumido(nome, pageable);
+        }
 
         return page.map(dto -> new AlunoResumoDTO(
                 dto.getId(),


### PR DESCRIPTION
Close #338 

# O que mudou?

Agora a tela de alunos em admin lista todos os alunos presente no banco, e possui suporte para filtragem por alunos ativos em turmas.

## Tarefas Relacionadas

* Issue: https://github.com/IFPBEsp/APAE-gestao-escolar/issues/338
* Outras dependências: {pr_link}

## Mudanças Realizadas

* Mudança no `AlunoService` em `listarAlunosPorNome`, adicionado variavel de boolean de apenasAtivos.
* Mudança no `AlunoRepository`, adicionado as funções `listarAlunosAtivosResumido` e `listarAlunosAtivosPorNomeResumido `para filtragem.
* Mudança no `AlunoController` no valor de size= 30, para retornar todos os alunos do banco, e no RequestParam boolean de apenasAtivos.

## Evidências

filtro no swagger:
<img width="1439" height="731" alt="image" src="https://github.com/user-attachments/assets/38252a00-347e-46ab-8223-9aa1413de969" />

lista de alunos:
<img width="1439" height="734" alt="image" src="https://github.com/user-attachments/assets/12ee8736-0724-49d1-89ae-bc28a69e74f4" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added filter option to display only active students in student listings.
  * Updated default pagination to show 30 results per page (previously 12).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->