### PR TITLE
[FEATURE] Criar metodos para redefinição de senha para professor

### DIFF
--- a/api/src/main/java/com/apae/gestao/config/SecurityConfig.java
+++ b/api/src/main/java/com/apae/gestao/config/SecurityConfig.java
@@ -32,6 +32,7 @@ public class SecurityConfig {
                         .requestMatchers(
                                 "/api/auth/login",
                                 "/api/auth/primeiro-acesso",
+                                "/api/auth/redefinir-senha",
                                 "/v3/api-docs/**",
                                 "/swagger-ui/**",
                                 "/swagger-ui.html",

--- a/api/src/main/java/com/apae/gestao/controller/AlunoController.java
+++ b/api/src/main/java/com/apae/gestao/controller/AlunoController.java
@@ -1,13 +1,12 @@
 package com.apae.gestao.controller;
 
-import com.apae.gestao.dto.AlunoTurmaRequestDTO;
-import com.apae.gestao.dto.AvaliacaoHistoricoResponseDTO;
+import com.apae.gestao.dto.aluno.AlunoTurmaRequestDTO;
+import com.apae.gestao.dto.avaliacao.AvaliacaoHistoricoResponseDTO;
 import com.apae.gestao.dto.aluno.AlunoDetalhesDTO;
 import com.apae.gestao.dto.aluno.AlunoResumoDTO;
 import com.apae.gestao.dto.aluno.AlunoTurmaHistoricoItemDTO;
 import com.apae.gestao.dto.aluno.AlunoTurmaHistoricoResponseDTO;
 import com.apae.gestao.service.AlunoService;
-import com.apae.gestao.openapi.Doc400ValidationError;
 import com.apae.gestao.openapi.Doc404NotFound;
 import com.apae.gestao.openapi.DocStandardErrors;
 

--- a/api/src/main/java/com/apae/gestao/controller/AuthController.java
+++ b/api/src/main/java/com/apae/gestao/controller/AuthController.java
@@ -1,8 +1,9 @@
 package com.apae.gestao.controller;
 
-import com.apae.gestao.dto.LoginRequestDTO;
-import com.apae.gestao.dto.LoginResponseDTO;
-import com.apae.gestao.dto.PrimeiroAcessoRequestDTO;
+import com.apae.gestao.dto.auth.LoginRequestDTO;
+import com.apae.gestao.dto.auth.LoginResponseDTO;
+import com.apae.gestao.dto.auth.PrimeiroAcessoRequestDTO;
+import com.apae.gestao.dto.auth.RecuperarSenhaRequestDTO;
 import com.apae.gestao.service.AuthService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -54,6 +55,23 @@ public class AuthController {
             @RequestBody PrimeiroAcessoRequestDTO request
     ) {
         authService.primeiroAcesso(request);
+        return ResponseEntity.ok().build();
+    }
+
+    @PostMapping("/redefinir-senha")
+    @Operation(
+            summary = "Solicitar redefinição de senha para professores",
+            description = "Recebe o e-mail e o CPF do professor. Se os dados baterem com o banco de dados, o status de 'primeiro acesso' do professor é reativado, permitindo que ele defina uma nova senha."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Solicitação processada com sucesso (primeiro acesso reativado)"),
+            @ApiResponse(responseCode = "400", description = "Dados inválidos (CPF incorreto ou dados em branco)"),
+            @ApiResponse(responseCode = "404", description = "Professor não encontrado para o e-mail informado")
+    })
+    public ResponseEntity<Void> redefinirSenha(@Valid @RequestBody RecuperarSenhaRequestDTO request) {
+
+        authService.redefinirSenha(request);
+
         return ResponseEntity.ok().build();
     }
 }

--- a/api/src/main/java/com/apae/gestao/controller/AuthController.java
+++ b/api/src/main/java/com/apae/gestao/controller/AuthController.java
@@ -3,7 +3,7 @@ package com.apae.gestao.controller;
 import com.apae.gestao.dto.auth.LoginRequestDTO;
 import com.apae.gestao.dto.auth.LoginResponseDTO;
 import com.apae.gestao.dto.auth.PrimeiroAcessoRequestDTO;
-import com.apae.gestao.dto.auth.RecuperarSenhaRequestDTO;
+import com.apae.gestao.dto.auth.RedefinirSenhaRequestDTO;
 import com.apae.gestao.service.AuthService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -68,7 +68,7 @@ public class AuthController {
             @ApiResponse(responseCode = "400", description = "Dados inválidos (CPF incorreto ou dados em branco)"),
             @ApiResponse(responseCode = "404", description = "Professor não encontrado para o e-mail informado")
     })
-    public ResponseEntity<Void> redefinirSenha(@Valid @RequestBody RecuperarSenhaRequestDTO request) {
+    public ResponseEntity<Void> redefinirSenha(@Valid @RequestBody RedefinirSenhaRequestDTO request) {
 
         authService.redefinirSenha(request);
 

--- a/api/src/main/java/com/apae/gestao/controller/AvaliacaoController.java
+++ b/api/src/main/java/com/apae/gestao/controller/AvaliacaoController.java
@@ -1,7 +1,7 @@
 package com.apae.gestao.controller;
 
-import com.apae.gestao.dto.AvaliacaoRequestDTO;
-import com.apae.gestao.dto.AvaliacaoResponseDTO;
+import com.apae.gestao.dto.avaliacao.AvaliacaoRequestDTO;
+import com.apae.gestao.dto.avaliacao.AvaliacaoResponseDTO;
 import com.apae.gestao.service.AvaliacaoService;
 import com.apae.gestao.openapi.Doc400ValidationError;
 import com.apae.gestao.openapi.Doc404NotFound;

--- a/api/src/main/java/com/apae/gestao/controller/PresencaController.java
+++ b/api/src/main/java/com/apae/gestao/controller/PresencaController.java
@@ -1,9 +1,8 @@
 package com.apae.gestao.controller;
 
-import com.apae.gestao.dto.ChamadaResponseDTO;
-import com.apae.gestao.dto.RegistrarChamadaRequestDTO;
+import com.apae.gestao.dto.aula.chamada.ChamadaResponseDTO;
+import com.apae.gestao.dto.aula.chamada.RegistrarChamadaRequestDTO;
 import com.apae.gestao.service.PresencaService;
-import com.apae.gestao.openapi.Doc400ValidationError;
 import com.apae.gestao.openapi.Doc404NotFound;
 import com.apae.gestao.openapi.DocStandardErrors;
 

--- a/api/src/main/java/com/apae/gestao/controller/ProfessorController.java
+++ b/api/src/main/java/com/apae/gestao/controller/ProfessorController.java
@@ -1,8 +1,11 @@
 package com.apae.gestao.controller;
 
 import java.util.List;
-import com.apae.gestao.dto.*;
-import com.apae.gestao.dto.turma.TurmaResponseDTO;
+
+import com.apae.gestao.dto.professor.ProfessorRequestDTO;
+import com.apae.gestao.dto.professor.ProfessorResponseDTO;
+import com.apae.gestao.dto.professor.ProfessorResumoDTO;
+import com.apae.gestao.dto.turma.TurmaResumoDTO;
 import com.apae.gestao.service.ProfessorService;
 import com.apae.gestao.openapi.Doc400ValidationError;
 import com.apae.gestao.openapi.Doc404NotFound;

--- a/api/src/main/java/com/apae/gestao/controller/RelatorioController.java
+++ b/api/src/main/java/com/apae/gestao/controller/RelatorioController.java
@@ -2,8 +2,8 @@ package com.apae.gestao.controller;
 
 import java.util.List;
 
-import com.apae.gestao.dto.RelatorioRequestDTO;
-import com.apae.gestao.dto.RelatorioResponseDTO;
+import com.apae.gestao.dto.relatorio.RelatorioRequestDTO;
+import com.apae.gestao.dto.relatorio.RelatorioResponseDTO;
 import com.apae.gestao.service.RelatorioService;
 import com.apae.gestao.openapi.Doc400ValidationError;
 import com.apae.gestao.openapi.Doc404NotFound;

--- a/api/src/main/java/com/apae/gestao/controller/TurmaController.java
+++ b/api/src/main/java/com/apae/gestao/controller/TurmaController.java
@@ -2,12 +2,11 @@ package com.apae.gestao.controller;
 
 import java.util.List;
 
-import com.apae.gestao.dto.*;
+import com.apae.gestao.dto.turma.TurmaResumoDTO;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 
-import com.apae.gestao.dto.ApiErrorResponse;
 import com.apae.gestao.dto.turma.TurmaRequestDTO;
 import com.apae.gestao.dto.turma.TurmaResponseDTO;
 import com.apae.gestao.dto.turmaAluno.TurmaAlunoResponseDTO;

--- a/api/src/main/java/com/apae/gestao/dto/aluno/AlunoResponseDTO.java
+++ b/api/src/main/java/com/apae/gestao/dto/aluno/AlunoResponseDTO.java
@@ -1,4 +1,4 @@
-package com.apae.gestao.dto;
+package com.apae.gestao.dto.aluno;
 
 import com.apae.gestao.entity.Aluno;
 import com.apae.gestao.entity.Turma;

--- a/api/src/main/java/com/apae/gestao/dto/aluno/AlunoTurmaRequestDTO.java
+++ b/api/src/main/java/com/apae/gestao/dto/aluno/AlunoTurmaRequestDTO.java
@@ -1,4 +1,4 @@
-package com.apae.gestao.dto;
+package com.apae.gestao.dto.aluno;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;

--- a/api/src/main/java/com/apae/gestao/dto/api/ApiErrorResponse.java
+++ b/api/src/main/java/com/apae/gestao/dto/api/ApiErrorResponse.java
@@ -1,4 +1,4 @@
-package com.apae.gestao.dto;
+package com.apae.gestao.dto.api;
 
 import java.time.LocalDateTime;
 import java.util.Map;

--- a/api/src/main/java/com/apae/gestao/dto/aula/chamada/ChamadaResponseDTO.java
+++ b/api/src/main/java/com/apae/gestao/dto/aula/chamada/ChamadaResponseDTO.java
@@ -1,4 +1,4 @@
-package com.apae.gestao.dto;
+package com.apae.gestao.dto.aula.chamada;
 import java.time.LocalDate;
 import java.util.List;
 

--- a/api/src/main/java/com/apae/gestao/dto/aula/chamada/PresencaAlunoDTO.java
+++ b/api/src/main/java/com/apae/gestao/dto/aula/chamada/PresencaAlunoDTO.java
@@ -1,4 +1,4 @@
-package com.apae.gestao.dto;
+package com.apae.gestao.dto.aula.chamada;
 
 import lombok.AllArgsConstructor;
 import lombok.Builder;

--- a/api/src/main/java/com/apae/gestao/dto/aula/chamada/RegistrarChamadaRequestDTO.java
+++ b/api/src/main/java/com/apae/gestao/dto/aula/chamada/RegistrarChamadaRequestDTO.java
@@ -1,4 +1,4 @@
-package com.apae.gestao.dto;
+package com.apae.gestao.dto.aula.chamada;
 
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotEmpty;

--- a/api/src/main/java/com/apae/gestao/dto/auth/LoginRequestDTO.java
+++ b/api/src/main/java/com/apae/gestao/dto/auth/LoginRequestDTO.java
@@ -1,4 +1,4 @@
-package com.apae.gestao.dto;
+package com.apae.gestao.dto.auth;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;

--- a/api/src/main/java/com/apae/gestao/dto/auth/LoginResponseDTO.java
+++ b/api/src/main/java/com/apae/gestao/dto/auth/LoginResponseDTO.java
@@ -1,4 +1,4 @@
-package com.apae.gestao.dto;
+package com.apae.gestao.dto.auth;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;

--- a/api/src/main/java/com/apae/gestao/dto/auth/PrimeiroAcessoRequestDTO.java
+++ b/api/src/main/java/com/apae/gestao/dto/auth/PrimeiroAcessoRequestDTO.java
@@ -1,4 +1,4 @@
-package com.apae.gestao.dto;
+package com.apae.gestao.dto.auth;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;

--- a/api/src/main/java/com/apae/gestao/dto/auth/RecuperarSenhaRequestDTO.java
+++ b/api/src/main/java/com/apae/gestao/dto/auth/RecuperarSenhaRequestDTO.java
@@ -1,0 +1,22 @@
+package com.apae.gestao.dto.auth;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Schema(description = "Dados necessários para solicitar a recuperação de senha.")
+public class RecuperarSenhaRequestDTO {
+
+    @NotBlank(message = "O e-mail é obrigatório")
+    @Schema(description = "E-mail do professor", example = "maria.santos@apae.org.br")
+    private String email;
+
+    @NotBlank(message = "O CPF é obrigatório")
+    @Schema(description = "CPF do professor", example = "12345678900")
+    private String cpf;
+}

--- a/api/src/main/java/com/apae/gestao/dto/auth/RedefinirSenhaRequestDTO.java
+++ b/api/src/main/java/com/apae/gestao/dto/auth/RedefinirSenhaRequestDTO.java
@@ -10,7 +10,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 @Schema(description = "Dados necessários para solicitar a recuperação de senha.")
-public class RecuperarSenhaRequestDTO {
+public class RedefinirSenhaRequestDTO {
 
     @NotBlank(message = "O e-mail é obrigatório")
     @Schema(description = "E-mail do professor", example = "maria.santos@apae.org.br")

--- a/api/src/main/java/com/apae/gestao/dto/avaliacao/AvaliacaoHistoricoResponseDTO.java
+++ b/api/src/main/java/com/apae/gestao/dto/avaliacao/AvaliacaoHistoricoResponseDTO.java
@@ -1,4 +1,4 @@
-package com.apae.gestao.dto;
+package com.apae.gestao.dto.avaliacao;
 
 import com.apae.gestao.entity.Avaliacao;
 import lombok.AllArgsConstructor;

--- a/api/src/main/java/com/apae/gestao/dto/avaliacao/AvaliacaoRequestDTO.java
+++ b/api/src/main/java/com/apae/gestao/dto/avaliacao/AvaliacaoRequestDTO.java
@@ -1,4 +1,4 @@
-package com.apae.gestao.dto;
+package com.apae.gestao.dto.avaliacao;
 
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;

--- a/api/src/main/java/com/apae/gestao/dto/avaliacao/AvaliacaoResponseDTO.java
+++ b/api/src/main/java/com/apae/gestao/dto/avaliacao/AvaliacaoResponseDTO.java
@@ -1,4 +1,4 @@
-package com.apae.gestao.dto;
+package com.apae.gestao.dto.avaliacao;
 
 import com.apae.gestao.entity.Avaliacao;
 import lombok.AllArgsConstructor;

--- a/api/src/main/java/com/apae/gestao/dto/professor/ProfessorRequestDTO.java
+++ b/api/src/main/java/com/apae/gestao/dto/professor/ProfessorRequestDTO.java
@@ -1,4 +1,4 @@
-package com.apae.gestao.dto;
+package com.apae.gestao.dto.professor;
 
 import java.time.LocalDate;
 import java.util.Set;

--- a/api/src/main/java/com/apae/gestao/dto/professor/ProfessorResponseDTO.java
+++ b/api/src/main/java/com/apae/gestao/dto/professor/ProfessorResponseDTO.java
@@ -1,4 +1,4 @@
-package com.apae.gestao.dto;
+package com.apae.gestao.dto.professor;
 
 import com.apae.gestao.entity.Professor;
 import com.apae.gestao.entity.Turma;

--- a/api/src/main/java/com/apae/gestao/dto/professor/ProfessorResumoDTO.java
+++ b/api/src/main/java/com/apae/gestao/dto/professor/ProfessorResumoDTO.java
@@ -1,4 +1,4 @@
-package com.apae.gestao.dto;
+package com.apae.gestao.dto.professor;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;

--- a/api/src/main/java/com/apae/gestao/dto/relatorio/RelatorioHistoricoResponseDTO.java
+++ b/api/src/main/java/com/apae/gestao/dto/relatorio/RelatorioHistoricoResponseDTO.java
@@ -1,4 +1,4 @@
-package com.apae.gestao.dto;
+package com.apae.gestao.dto.relatorio;
 
 import com.apae.gestao.entity.Relatorio;
 import lombok.AllArgsConstructor;

--- a/api/src/main/java/com/apae/gestao/dto/relatorio/RelatorioRequestDTO.java
+++ b/api/src/main/java/com/apae/gestao/dto/relatorio/RelatorioRequestDTO.java
@@ -1,4 +1,4 @@
-package com.apae.gestao.dto;
+package com.apae.gestao.dto.relatorio;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;

--- a/api/src/main/java/com/apae/gestao/dto/relatorio/RelatorioResponseDTO.java
+++ b/api/src/main/java/com/apae/gestao/dto/relatorio/RelatorioResponseDTO.java
@@ -1,4 +1,4 @@
-package com.apae.gestao.dto;
+package com.apae.gestao.dto.relatorio;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;

--- a/api/src/main/java/com/apae/gestao/dto/turma/TurmaResumoDTO.java
+++ b/api/src/main/java/com/apae/gestao/dto/turma/TurmaResumoDTO.java
@@ -1,4 +1,4 @@
-package com.apae.gestao.dto;
+package com.apae.gestao.dto.turma;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;

--- a/api/src/main/java/com/apae/gestao/exception/GlobalExceptionHandler.java
+++ b/api/src/main/java/com/apae/gestao/exception/GlobalExceptionHandler.java
@@ -4,7 +4,7 @@ import java.time.LocalDateTime;
 import java.util.Map;
 import java.util.stream.Collectors;
 
-import com.apae.gestao.dto.ApiErrorResponse;
+import com.apae.gestao.dto.api.ApiErrorResponse;
 
 import jakarta.servlet.http.HttpServletRequest;
 

--- a/api/src/main/java/com/apae/gestao/openapi/Doc400ValidationError.java
+++ b/api/src/main/java/com/apae/gestao/openapi/Doc400ValidationError.java
@@ -1,6 +1,6 @@
 package com.apae.gestao.openapi;
 
-import com.apae.gestao.dto.ApiErrorResponse;
+import com.apae.gestao.dto.api.ApiErrorResponse;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;

--- a/api/src/main/java/com/apae/gestao/openapi/Doc404NotFound.java
+++ b/api/src/main/java/com/apae/gestao/openapi/Doc404NotFound.java
@@ -1,6 +1,6 @@
 package com.apae.gestao.openapi;
 
-import com.apae.gestao.dto.ApiErrorResponse;
+import com.apae.gestao.dto.api.ApiErrorResponse;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;

--- a/api/src/main/java/com/apae/gestao/service/AlunoService.java
+++ b/api/src/main/java/com/apae/gestao/service/AlunoService.java
@@ -1,7 +1,7 @@
 package com.apae.gestao.service;
 
-import com.apae.gestao.dto.AlunoTurmaRequestDTO;
-import com.apae.gestao.dto.AvaliacaoHistoricoResponseDTO;
+import com.apae.gestao.dto.aluno.AlunoTurmaRequestDTO;
+import com.apae.gestao.dto.avaliacao.AvaliacaoHistoricoResponseDTO;
 import com.apae.gestao.dto.aluno.AlunoDetalhesDTO;
 import com.apae.gestao.dto.aluno.AlunoResumoDTO;
 import com.apae.gestao.dto.aluno.AlunoTurmaHistoricoResponseDTO;

--- a/api/src/main/java/com/apae/gestao/service/AuthService.java
+++ b/api/src/main/java/com/apae/gestao/service/AuthService.java
@@ -3,7 +3,7 @@ package com.apae.gestao.service;
 import com.apae.gestao.dto.auth.LoginRequestDTO;
 import com.apae.gestao.dto.auth.LoginResponseDTO;
 import com.apae.gestao.dto.auth.PrimeiroAcessoRequestDTO;
-import com.apae.gestao.dto.auth.RecuperarSenhaRequestDTO;
+import com.apae.gestao.dto.auth.RedefinirSenhaRequestDTO;
 import com.apae.gestao.entity.Professor;
 import com.apae.gestao.repository.ProfessorRepository;
 import com.apae.gestao.security.JwtService;
@@ -90,7 +90,7 @@ public class AuthService {
         professorRepository.save(professor);
     }
 
-    public void redefinirSenha(RecuperarSenhaRequestDTO request){
+    public void redefinirSenha(RedefinirSenhaRequestDTO request){
 
         Professor professor = professorRepository.findByEmail(request.getEmail())
                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Professor com email não cadastrado"));

--- a/api/src/main/java/com/apae/gestao/service/AuthService.java
+++ b/api/src/main/java/com/apae/gestao/service/AuthService.java
@@ -95,12 +95,14 @@ public class AuthService {
         Professor professor = professorRepository.findByEmail(request.getEmail())
                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Professor com email não cadastrado"));
 
-        if(!professor.getCpf().equals(request.getCpf())){
+        String cpfRequestSomenteDigitos = request.getCpf().replaceAll("\\D", "");
+        String cpfBancoSomenteDigitos = professor.getCpf().replaceAll("\\D", "");
+
+        if(!cpfBancoSomenteDigitos.equals(cpfRequestSomenteDigitos)){
             throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Dados inválidos");
         }
 
-        String cpfSomenteDigitos = request.getCpf().replaceAll("\\D", "");
-        professor.setSenha(passwordEncoder.encode(cpfSomenteDigitos));
+        professor.setSenha(passwordEncoder.encode(cpfRequestSomenteDigitos));
         professor.setPrimeiroAcesso(true);
         professorRepository.save(professor);
     }

--- a/api/src/main/java/com/apae/gestao/service/AuthService.java
+++ b/api/src/main/java/com/apae/gestao/service/AuthService.java
@@ -96,10 +96,11 @@ public class AuthService {
                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Professor com email não cadastrado"));
 
         if(!professor.getCpf().equals(request.getCpf())){
-            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Cpf errado");
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Dados inválidos");
         }
 
-        professor.setSenha(null);
+        String cpfSomenteDigitos = request.getCpf().replaceAll("\\D", "");
+        professor.setSenha(passwordEncoder.encode(cpfSomenteDigitos));
         professor.setPrimeiroAcesso(true);
         professorRepository.save(professor);
     }

--- a/api/src/main/java/com/apae/gestao/service/AuthService.java
+++ b/api/src/main/java/com/apae/gestao/service/AuthService.java
@@ -1,8 +1,9 @@
 package com.apae.gestao.service;
 
-import com.apae.gestao.dto.LoginRequestDTO;
-import com.apae.gestao.dto.LoginResponseDTO;
-import com.apae.gestao.dto.PrimeiroAcessoRequestDTO;
+import com.apae.gestao.dto.auth.LoginRequestDTO;
+import com.apae.gestao.dto.auth.LoginResponseDTO;
+import com.apae.gestao.dto.auth.PrimeiroAcessoRequestDTO;
+import com.apae.gestao.dto.auth.RecuperarSenhaRequestDTO;
 import com.apae.gestao.entity.Professor;
 import com.apae.gestao.repository.ProfessorRepository;
 import com.apae.gestao.security.JwtService;
@@ -88,4 +89,19 @@ public class AuthService {
         professor.setPrimeiroAcesso(false);
         professorRepository.save(professor);
     }
+
+    public void redefinirSenha(RecuperarSenhaRequestDTO request){
+
+        Professor professor = professorRepository.findByEmail(request.getEmail())
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Professor com email não cadastrado"));
+
+        if(!professor.getCpf().equals(request.getCpf())){
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Cpf errado");
+        }
+
+        professor.setSenha(null);
+        professor.setPrimeiroAcesso(true);
+        professorRepository.save(professor);
+    }
+
 }

--- a/api/src/main/java/com/apae/gestao/service/AvaliacaoService.java
+++ b/api/src/main/java/com/apae/gestao/service/AvaliacaoService.java
@@ -1,7 +1,7 @@
 package com.apae.gestao.service;
 
-import com.apae.gestao.dto.AvaliacaoRequestDTO;
-import com.apae.gestao.dto.AvaliacaoResponseDTO;
+import com.apae.gestao.dto.avaliacao.AvaliacaoRequestDTO;
+import com.apae.gestao.dto.avaliacao.AvaliacaoResponseDTO;
 import com.apae.gestao.entity.Avaliacao;
 import com.apae.gestao.entity.Aluno;
 import com.apae.gestao.entity.Professor;

--- a/api/src/main/java/com/apae/gestao/service/PresencaService.java
+++ b/api/src/main/java/com/apae/gestao/service/PresencaService.java
@@ -1,8 +1,8 @@
 package com.apae.gestao.service;
 
-import com.apae.gestao.dto.ChamadaResponseDTO;
-import com.apae.gestao.dto.PresencaAlunoDTO;
-import com.apae.gestao.dto.RegistrarChamadaRequestDTO;
+import com.apae.gestao.dto.aula.chamada.ChamadaResponseDTO;
+import com.apae.gestao.dto.aula.chamada.PresencaAlunoDTO;
+import com.apae.gestao.dto.aula.chamada.RegistrarChamadaRequestDTO;
 import com.apae.gestao.entity.*;
 import com.apae.gestao.repository.*;
 import com.fasterxml.jackson.databind.ObjectMapper;

--- a/api/src/main/java/com/apae/gestao/service/ProfessorService.java
+++ b/api/src/main/java/com/apae/gestao/service/ProfessorService.java
@@ -1,7 +1,9 @@
 package com.apae.gestao.service;
 
-import com.apae.gestao.dto.*;
-import com.apae.gestao.dto.turma.TurmaResponseDTO;
+import com.apae.gestao.dto.professor.ProfessorRequestDTO;
+import com.apae.gestao.dto.professor.ProfessorResponseDTO;
+import com.apae.gestao.dto.professor.ProfessorResumoDTO;
+import com.apae.gestao.dto.turma.TurmaResumoDTO;
 import com.apae.gestao.entity.Professor;
 import com.apae.gestao.entity.Turma;
 import com.apae.gestao.exception.ConflitoDeDadosException;

--- a/api/src/main/java/com/apae/gestao/service/RelatorioService.java
+++ b/api/src/main/java/com/apae/gestao/service/RelatorioService.java
@@ -1,7 +1,7 @@
 package com.apae.gestao.service;
 
-import com.apae.gestao.dto.RelatorioRequestDTO;
-import com.apae.gestao.dto.RelatorioResponseDTO;
+import com.apae.gestao.dto.relatorio.RelatorioRequestDTO;
+import com.apae.gestao.dto.relatorio.RelatorioResponseDTO;
 import com.apae.gestao.entity.*;
 import com.apae.gestao.repository.*;
 

--- a/api/src/main/java/com/apae/gestao/service/TurmaService.java
+++ b/api/src/main/java/com/apae/gestao/service/TurmaService.java
@@ -6,7 +6,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-import com.apae.gestao.dto.*;
+import com.apae.gestao.dto.turma.TurmaResumoDTO;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;


### PR DESCRIPTION
Close #341 

# O que mudou?

Agora a api possui métodos para redefinição de senha para professores caso haja necessidade, também modifiquei a pasta dos DTO's para melhor organização e visualização.

## Tarefas Relacionadas

* Issue: https://github.com/IFPBEsp/APAE-gestao-escolar/issues/341
* Outras dependências: 

## Mudanças Realizadas

* Criação da função de `redefinirSenha` em `AuthService`.
* Criação do endpoint de `redefinirSenha` em `AuthController`.
* Criação do **DTO** de `RedefinirSenhaRequestDTO` na pasta de `dto`
* Mudança nos pacotes de dto para melhor organização, (criei algumas pastas para separar os dtos)

## Evidências

pasta dto:
<img width="312" height="242" alt="image" src="https://github.com/user-attachments/assets/523ed302-059c-4efa-9d04-83b992ef8caf" />

função (AuthService):
<img width="821" height="356" alt="image" src="https://github.com/user-attachments/assets/85134c1d-a9e3-448a-b324-56e23de9d73c" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Password reset endpoint: users can request a password reset by providing registered email and CPF; on success the account is marked for first-time login and a new password must be set at next sign-in.
* **Security**
  * Password reset route is publicly accessible (no authentication required).
* **Chores**
  * Internal DTO/package reorganization and minor cleanup (no behavior changes).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->