### PR TITLE
[REFACTOR] Ajustar espaçamento e quinas nos cards da tela de gestão d…

### DIFF
--- a/app/src/app/professor/turmas/[turmaId]/frequencia/page.tsx
+++ b/app/src/app/professor/turmas/[turmaId]/frequencia/page.tsx
@@ -137,7 +137,7 @@ export default function FrequenciaPage() {
                 </div>
 
                 <div id="secao-chamada">
-                <Card className="rounded-xl border-2 border-[#B2D7EC] shadow-md bg-white">
+                <Card className="rounded-xl border-2 border-[#B2D7EC] shadow-md bg-white overflow-hidden">
                     <CardHeader className="bg-[#F8F9FA] border-b-2 border-[#B2D7EC]">
                         <CardTitle className="text-[#0D4F97]">
                             Registrar Chamada
@@ -147,7 +147,7 @@ export default function FrequenciaPage() {
                     </CardDescription>
                         </CardHeader>
 
-                        <CardContent className="p-6">
+                        <CardContent className="p-6 pt-6">
                     <ChamadaContent
                         turmaId={turmaId}
                         alunos={alunos}
@@ -500,7 +500,7 @@ function HistoricoContent({
     });
 
     return (
-        <Card className="rounded-xl border-2 border-[#B2D7EC] shadow-md bg-white">
+        <Card className="rounded-xl border-2 border-[#B2D7EC] shadow-md bg-white overflow-hidden">
             <CardHeader className="bg-[#F8F9FA] border-b-2 border-[#B2D7EC]">
                 <div className="flex justify-between items-center">
                     <div>
@@ -511,8 +511,8 @@ function HistoricoContent({
                     </div>
                 </div>
             </CardHeader>
-            <CardContent className="p-6 space-y-6">
-                <div className="grid grid-cols-1 gap-4 sm:grid-cols-3 mt-6">
+            <CardContent className="p-6 pt-6 space-y-6">
+                <div className="grid grid-cols-1 gap-4 sm:grid-cols-3">
                     <Card className="rounded-xl border-2 border-[#B2D7EC] shadow-md">
                         <CardContent className="p-6 pt-12 text-center flex flex-col items-center justify-start h-full">
                             <p className="text-[#0D4F97] text-2xl font-bold">{mediaFrequencia}%</p>


### PR DESCRIPTION
…e frequência

# O que mudou?

O objetivo deste Pull Request é refinar a interface gráfica da tela de "Gestão de Frequência", corrigindo inconsistências visuais nos cards principais (Registrar Chamada e Histórico de Frequência) para oferecer uma experiência mais polida e profissional aos professores.

## Tarefas Relacionadas

* Issue: {issue_link} #336 
* Outras dependências: {pr_link}

## Mudanças Realizadas

* Correção das Quinas Quebradas: Adição da classe utilitária overflow-hidden aos componentes Card principais. Isso garante que o fundo (bg) do CardHeader não vaze por cima da borda arredondada (rounded-xl), tornando o perímetro da borda totalmente contínuo.

* Padronização do Espaçamento Vertical: Ajuste das classes de padding no CardContent. Foi adicionado o pt-6 explícito para anular o comportamento padrão do componente base e foi removido o mt-6 "hardcoded" que existia no histórico. Dessa forma, todos os cards na tela mantêm exatamente a mesma distância padronizada (24px) entre o cabeçalho e os elementos internos.


## Evidências

<img width="1890" height="948" alt="Screenshot 2026-05-03 195848" src="https://github.com/user-attachments/assets/74198c20-97ef-4aaa-9412-362951c5e755" />
<img width="1897" height="951" alt="Screenshot 2026-05-03 195918" src="https://github.com/user-attachments/assets/1ed5d58e-44ed-4915-87d9-8e88d687d649" />
