### PR TITLE
[Refactor] Entidades dependentes, relacionamentos e PKs.

### DIFF
--- a/api/src/main/java/com/apae/gestao/entity/Aula.java
+++ b/api/src/main/java/com/apae/gestao/entity/Aula.java
@@ -21,6 +21,7 @@ import java.util.UUID;
 public class Aula {
 
     @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
     private UUID id;
 
     private LocalDate data;

--- a/api/src/main/java/com/apae/gestao/entity/Aula.java
+++ b/api/src/main/java/com/apae/gestao/entity/Aula.java
@@ -9,28 +9,26 @@ import java.time.LocalDate;
 import java.util.HashSet;
 import java.util.Objects;
 import java.util.Set;
+import java.util.UUID;
 
 @Entity
-@Table(name = "aulas")
 @Data
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
 @JsonIdentityInfo(generator = ObjectIdGenerators.PropertyGenerator.class, property = "id")
-
+@Table(name = "aulas", schema = "gestao_escolar")
 public class Aula {
+
     @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long id;
+    private UUID id;
 
-    @Column(name = "data_da_aula", nullable = false)
-    private LocalDate dataDaAula;
+    private LocalDate data;
 
-    @Column(nullable = false)
     private String descricao;
 
     @ManyToOne
-    @JoinColumn(name = "turmas_id")
+    @JoinColumn(name = "turma_id")
     private Turma turma;
 
     @OneToMany(mappedBy = "aula", cascade = CascadeType.ALL)

--- a/api/src/main/java/com/apae/gestao/entity/Avaliacao.java
+++ b/api/src/main/java/com/apae/gestao/entity/Avaliacao.java
@@ -22,6 +22,7 @@ import lombok.*;
 public class Avaliacao {
     
     @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
     private UUID id;
 
     private String descricao; 

--- a/api/src/main/java/com/apae/gestao/entity/Avaliacao.java
+++ b/api/src/main/java/com/apae/gestao/entity/Avaliacao.java
@@ -2,6 +2,7 @@ package com.apae.gestao.entity;
 
 import java.time.LocalDateTime;
 import java.util.Objects;
+import java.util.UUID;
 
 import com.fasterxml.jackson.annotation.JsonIdentityInfo;
 import com.fasterxml.jackson.annotation.ObjectIdGenerators;
@@ -10,33 +11,29 @@ import jakarta.persistence.*;
 import lombok.*;
 
 @Entity
-@Table(name = "avaliacoes")
 @Data
 @NoArgsConstructor
 @AllArgsConstructor
 @Getter
 @Setter
 @Builder
-@EqualsAndHashCode
 @JsonIdentityInfo(generator = ObjectIdGenerators.PropertyGenerator.class, property = "id")
+@Table(name = "avaliacoes", schema = "gestao_escolar")
 public class Avaliacao {
     
     @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long id;
-    
-    @Column(nullable = false, columnDefinition = "TEXT")
+    private UUID id;
+
     private String descricao; 
     
-    @Column(name = "data_avaliacao", nullable = false)
+    @Column(name = "data_avaliacao")
     private LocalDateTime dataAvaliacao;
+
+    @Column(name = "paciente_id")
+    private UUID pacienteId;
     
     @ManyToOne
-    @JoinColumn(name = "aluno_id", nullable = false)
-    private Aluno aluno;
-    
-    @ManyToOne
-    @JoinColumn(name = "professor_id", nullable = false)
+    @JoinColumn(name = "professor_id" )
     private Professor professor;
     
     @PrePersist

--- a/api/src/main/java/com/apae/gestao/entity/Presenca.java
+++ b/api/src/main/java/com/apae/gestao/entity/Presenca.java
@@ -4,28 +4,28 @@ import jakarta.persistence.*;
 import lombok.*;
 
 import java.util.Objects;
+import java.util.UUID;
 
 @Entity
-@Table(name = "presencas", uniqueConstraints = @UniqueConstraint(columnNames = {"alunos_id", "aulas_id"}))
 @Data
 @NoArgsConstructor
 @AllArgsConstructor
 @Getter@Setter
 @Builder
+@Table(name = "presencas", schema = "gestao_escolar", uniqueConstraints = @UniqueConstraint(columnNames = {"paciente_id", "aula_id"}))
 public class Presenca {
+
     @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long id;
+    private UUID id;
 
     @Column
     private Boolean faltou;
 
-    @ManyToOne
-    @JoinColumn(name = "alunos_id")
-    private Aluno aluno;
+    @Column(name = "paciente_id")
+    private UUID pacienteId;
 
     @ManyToOne
-    @JoinColumn(name = "aulas_id")
+    @JoinColumn(name = "aula_id")
     private Aula aula;
 
     @PrePersist
@@ -51,7 +51,7 @@ public class Presenca {
         return "Presenca{" +
                 "id=" + id +
                 ", faltou=" + faltou +
-                ", alunoId=" + (aluno != null ? aluno.getId() : null) +
+                ", pacienteId=" + (pacienteId!= null ? pacienteId : null) +
                 ", aulaId=" + (aula != null ? aula.getId() : null) +
                 '}';
     }

--- a/api/src/main/java/com/apae/gestao/entity/Presenca.java
+++ b/api/src/main/java/com/apae/gestao/entity/Presenca.java
@@ -16,6 +16,7 @@ import java.util.UUID;
 public class Presenca {
 
     @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
     private UUID id;
 
     @Column

--- a/api/src/main/java/com/apae/gestao/entity/Relatorio.java
+++ b/api/src/main/java/com/apae/gestao/entity/Relatorio.java
@@ -1,6 +1,7 @@
 package com.apae.gestao.entity;
 
 import java.time.LocalDateTime;
+import java.util.UUID;
 
 import com.fasterxml.jackson.annotation.JsonIdentityInfo;
 import com.fasterxml.jackson.annotation.ObjectIdGenerators;
@@ -9,41 +10,40 @@ import lombok.*;
 
 
 @Entity
-@Table(name = "relatorios")
 @Data
 @NoArgsConstructor
 @AllArgsConstructor
 @JsonIdentityInfo(generator = ObjectIdGenerators.PropertyGenerator.class, property = "id")
+@Table(name = "relatorios", schema = "gestao_escolar")
 public class Relatorio {
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long id;
 
-    @Column(length = 1000)
+    @Id
+    private UUID id;
+
+    @Column(columnDefinition = "TEXT")
     private String atividades;
 
-    @Column(length = 1000)
+    @Column(columnDefinition = "TEXT")
     private String habilidades;
 
-    @Column(length = 1000)
+    @Column(columnDefinition = "TEXT")
     private String estrategias;
 
-    @Column(length = 1000)
+    @Column(columnDefinition = "TEXT")
     private String recursos;
 
-    @Column(name = "created_at", nullable = false, updatable = false)
+    @Column(name = "created_at")
     private LocalDateTime createdAt;
 
-    @ManyToOne(fetch = FetchType.EAGER)
-    @JoinColumn(name = "aluno_id", nullable = false)
-    private Aluno aluno;
+    @Column(name = "paciente_id")
+    private UUID pacienteId;
 
     @ManyToOne(fetch = FetchType.EAGER)
-    @JoinColumn(name = "professor_id", nullable = false)
+    @JoinColumn(name = "professor_id" )
     private Professor professor;
 
     @ManyToOne(fetch = FetchType.EAGER)
-    @JoinColumn(name = "turma_id", nullable = false)
+    @JoinColumn(name = "turma_id" )
     private Turma turma;
 
     @PrePersist

--- a/api/src/main/java/com/apae/gestao/entity/Relatorio.java
+++ b/api/src/main/java/com/apae/gestao/entity/Relatorio.java
@@ -18,6 +18,7 @@ import lombok.*;
 public class Relatorio {
 
     @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
     private UUID id;
 
     @Column(columnDefinition = "TEXT")

--- a/api/src/main/java/com/apae/gestao/entity/TurmaAluno.java
+++ b/api/src/main/java/com/apae/gestao/entity/TurmaAluno.java
@@ -16,6 +16,7 @@ import java.util.UUID;
 public class TurmaAluno {
 
     @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
     private UUID id;
 
     @ManyToOne

--- a/api/src/main/java/com/apae/gestao/repository/AulaRepository.java
+++ b/api/src/main/java/com/apae/gestao/repository/AulaRepository.java
@@ -7,8 +7,9 @@ import org.springframework.stereotype.Repository;
 
 import java.time.LocalDate;
 import java.util.Optional;
+import java.util.UUID;
 
 @Repository
-public interface AulaRepository extends JpaRepository<Aula,Long> {
-    Optional<Aula> findByTurmaAndDataDaAula(Turma turma, LocalDate dataDaAula);
+public interface AulaRepository extends JpaRepository<Aula, UUID> {
+    Optional<Aula> findByTurmaAndData(Turma turma, LocalDate data);
 }

--- a/api/src/main/java/com/apae/gestao/repository/AvaliacaoRepository.java
+++ b/api/src/main/java/com/apae/gestao/repository/AvaliacaoRepository.java
@@ -1,21 +1,21 @@
 package com.apae.gestao.repository;
 
-import com.apae.gestao.entity.Aluno;
 import com.apae.gestao.entity.Avaliacao;
 import com.apae.gestao.entity.Professor;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
+import java.util.UUID;
 
 @Repository
-public interface AvaliacaoRepository extends JpaRepository<Avaliacao, Long> {
+public interface AvaliacaoRepository extends JpaRepository<Avaliacao, UUID> {
 
-    List<Avaliacao> findByAlunoOrderByDataAvaliacaoDesc(Aluno aluno);
+    List<Avaliacao> findByPacienteIdOrderByDataAvaliacaoDesc(UUID pacienteId);
 
     List<Avaliacao> findByProfessorOrderByDataAvaliacaoDesc(Professor professor);
 
-    List<Avaliacao> findByAlunoAndProfessorOrderByDataAvaliacaoDesc(Aluno aluno, Professor professor);
+    List<Avaliacao> findByPacienteIdAndProfessorOrderByDataAvaliacaoDesc(UUID pacienteId, Professor professor);
 
     List<Avaliacao> findAllByOrderByDataAvaliacaoDesc();
 }

--- a/api/src/main/java/com/apae/gestao/repository/PresencaRepository.java
+++ b/api/src/main/java/com/apae/gestao/repository/PresencaRepository.java
@@ -1,6 +1,5 @@
 package com.apae.gestao.repository;
 
-import com.apae.gestao.entity.Aluno;
 import com.apae.gestao.entity.Aula;
 import com.apae.gestao.entity.Presenca;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -11,14 +10,15 @@ import org.springframework.stereotype.Repository;
 import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
+import java.util.UUID;
 
 @Repository
-public interface PresencaRepository extends JpaRepository<Presenca, Long> {
+public interface PresencaRepository extends JpaRepository<Presenca, UUID> {
 
     List<Presenca> findByAula(Aula aula);
 
     @Query(value = "SELECT get_chamada_por_turma_e_data(:turmaId, :data)::text", nativeQuery = true)
-    String getChamadaPorTurmaEData(@Param("turmaId") Long turmaId, @Param("data") LocalDate data);
+    String getChamadaPorTurmaEData(@Param("turmaId") UUID turmaId, @Param("data") LocalDate data);
 
-    Optional<Presenca> findByAulaAndAluno(Aula aula, Aluno aluno);
+    Optional<Presenca> findByAulaAndPacienteId(Aula aula, UUID pacienteId);
 }

--- a/api/src/main/java/com/apae/gestao/repository/RelatorioRepository.java
+++ b/api/src/main/java/com/apae/gestao/repository/RelatorioRepository.java
@@ -4,8 +4,9 @@ import com.apae.gestao.entity.Relatorio;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 import java.util.List;
+import java.util.UUID;
 
 @Repository
-public interface RelatorioRepository extends JpaRepository<Relatorio, Long> {
-    List<Relatorio> findByAlunoId(Long alunoId);
+public interface RelatorioRepository extends JpaRepository<Relatorio, UUID> {
+    List<Relatorio> findByPacienteId(UUID pacienteId);
 }

--- a/api/src/main/java/com/apae/gestao/repository/TurmaAlunoRepository.java
+++ b/api/src/main/java/com/apae/gestao/repository/TurmaAlunoRepository.java
@@ -2,45 +2,46 @@ package com.apae.gestao.repository;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.UUID;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
-import com.apae.gestao.entity.Aluno;
 import com.apae.gestao.entity.Turma;
 import com.apae.gestao.entity.TurmaAluno;
 
 @Repository
-public interface TurmaAlunoRepository extends JpaRepository<TurmaAluno, Long>{
+public interface TurmaAlunoRepository extends JpaRepository<TurmaAluno, UUID>{
 
-    List<TurmaAluno> findByTurmaAndIsAlunoAtivo(Turma turma, Boolean isAlunoAtivo);
+    List<TurmaAluno> findByTurmaAndAtivo(Turma turma, Boolean ativo);
 
-    List<TurmaAluno> findByTurmaAndIsAlunoAtivoOrderByAlunoNomeAsc(Turma turma, Boolean isAlunoAtivo);
+    @Query("SELECT ta FROM TurmaAluno ta JOIN AlunoView a ON ta.pacienteId = a.id WHERE ta.turma = :turma AND ta.ativo = :ativo ORDER BY a.nomeCompleto ASC")
+    List<TurmaAluno> findByTurmaAndAtivoOrderByPacienteNomeAsc(@Param("turma") Turma turma, @Param("ativo") Boolean ativo);
 
-    Optional<TurmaAluno> findByTurmaAndAluno(Turma turma, Aluno aluno);
+    Optional<TurmaAluno> findByTurmaAndPacienteId(Turma turma, UUID pacienteId);
 
-    List<TurmaAluno> findAllByAlunoAndIsAlunoAtivoTrue(Aluno aluno);
+    List<TurmaAluno> findAllByPacienteIdAndAtivoTrue(UUID pacienteId);
 
     @Query("""
             SELECT DISTINCT ta FROM TurmaAluno ta
             JOIN FETCH ta.turma t
-            LEFT JOIN FETCH t.professor
-            WHERE ta.aluno = :aluno
+            WHERE ta.pacienteId = :pacienteId
             ORDER BY t.anoCriacao DESC, t.nome ASC
             """)
-    List<TurmaAluno> findAllHistoricoByAluno(@Param("aluno") Aluno aluno);
+    List<TurmaAluno> findAllHistoricoByPaciente(@Param("pacienteId") UUID pacienteId);
 
-    List<TurmaAluno> findByTurmaId(Long turmaId);
+    List<TurmaAluno> findByTurmaId(UUID turmaId);
 
-    List<TurmaAluno> findByTurmaIdOrderByAlunoNomeAsc(Long turmaId);
+    @Query("SELECT ta FROM TurmaAluno ta JOIN AlunoView a ON ta.pacienteId = a.id WHERE ta.turma.id = :turmaId ORDER BY a.nomeCompleto ASC")
+    List<TurmaAluno> findByTurmaIdOrderByPacienteNomeAsc(@Param("turmaId") UUID turmaId);
 
     @Query("""
             SELECT ta FROM TurmaAluno ta
             JOIN FETCH ta.turma t
-            WHERE ta.aluno = :aluno
-            ORDER BY ta.isAlunoAtivo DESC, t.anoCriacao DESC, t.nome ASC
+            WHERE ta.pacienteId = :pacienteId
+            ORDER BY ta.ativo DESC, t.anoCriacao DESC, t.nome ASC
             """)
-    List<TurmaAluno> findHistoricoCompletoPorAluno(@Param("aluno") Aluno aluno);
+    List<TurmaAluno> findHistoricoCompletoPorPaciente(@Param("pacienteId") UUID pacienteId);
 }

--- a/api/src/main/java/com/apae/gestao/service/AlunoService.java
+++ b/api/src/main/java/com/apae/gestao/service/AlunoService.java
@@ -72,7 +72,7 @@ public class AlunoService {
 
 
         turmaAlunoRepository
-                .findAllByAlunoAndIsAlunoAtivoTrue(aluno)
+                .findAllByPacienteIdAndAtivoTrue(aluno)
                 .forEach(ta -> ta.setIsAlunoAtivo(false));
 
         //busca se o aluno já tem registro no novaTurma para não criar uma nova instância de aluno no bd
@@ -105,7 +105,7 @@ public class AlunoService {
         Aluno aluno = alunoRepository.findById(id)
                 .orElseThrow(() -> new RuntimeException("Aluno não encontrado"));
 
-        return turmaAlunoRepository.findHistoricoCompletoPorAluno(aluno).stream()
+        return turmaAlunoRepository.findHistoricoCompletoPorPaciente(aluno).stream()
                 .map(AlunoTurmaHistoricoResponseDTO::from)
                 .toList();
     }
@@ -121,7 +121,7 @@ public class AlunoService {
                         .orElse("Sem turma ativa");
 
         return avaliacaoRepository
-                .findByAlunoOrderByDataAvaliacaoDesc(aluno)
+                .findByPacienteIdOrderByDataAvaliacaoDesc(aluno)
                 .stream()
                 .map(a -> AvaliacaoHistoricoResponseDTO.fromEntity(a, turmaAtual))
                 .toList();

--- a/api/src/main/java/com/apae/gestao/service/AvaliacaoService.java
+++ b/api/src/main/java/com/apae/gestao/service/AvaliacaoService.java
@@ -83,7 +83,7 @@ public class AvaliacaoService {
         Aluno aluno = alunoRepository.findById(alunoId)
                 .orElseThrow(() -> new EntityNotFoundException("Aluno não encontrado"));
         
-        return avaliacaoRepository.findByAlunoOrderByDataAvaliacaoDesc(aluno)
+        return avaliacaoRepository.findByPacienteIdOrderByDataAvaliacaoDesc(aluno)
                 .stream()
                 .map(avaliacao -> {
                     String turmaCompleta = getTurmaCompleta(avaliacao);

--- a/api/src/main/java/com/apae/gestao/service/PresencaService.java
+++ b/api/src/main/java/com/apae/gestao/service/PresencaService.java
@@ -50,7 +50,7 @@ public class PresencaService {
         Turma turma = turmaRepository.findById(turmaId)
                 .orElseThrow(() -> new RuntimeException("Turma não encontrada com id: " + turmaId));
 
-        Aula aula = aulaRepository.findByTurmaAndDataDaAula(turma, data)
+        Aula aula = aulaRepository.findByTurmaAndData(turma, data)
                 .orElseGet(() -> criarNovaAula(turma, data, request.getDescricao()));
 
         if (request.getDescricao() != null && !request.getDescricao().isBlank()) {
@@ -93,7 +93,7 @@ public class PresencaService {
         Aluno aluno = alunoRepository.findById(item.getAlunoId())
                 .orElseThrow(() -> new RuntimeException("Aluno não encontrado com id: " + item.getAlunoId()));
 
-        Presenca presenca = presencaRepository.findByAulaAndAluno(aula, aluno)
+        Presenca presenca = presencaRepository.findByAulaAndPacienteId(aula, aluno)
                 .orElseGet(() -> Presenca.builder()
                         .aula(aula)
                         .aluno(aluno)

--- a/api/src/main/java/com/apae/gestao/service/RelatorioService.java
+++ b/api/src/main/java/com/apae/gestao/service/RelatorioService.java
@@ -125,7 +125,7 @@ public class RelatorioService {
 
     @Transactional(readOnly = true)
         public List<RelatorioResponseDTO> buscarPorAluno(Long alunoId) {
-        return relatorioRepository.findByAlunoId(alunoId)
+        return relatorioRepository.findByPacienteId(alunoId)
                 .stream()
                 .map(this::toResponseDTO)
                 .collect(Collectors.toList());

--- a/api/src/main/java/com/apae/gestao/service/TurmaService.java
+++ b/api/src/main/java/com/apae/gestao/service/TurmaService.java
@@ -233,7 +233,7 @@ public class TurmaService {
 
     @Transactional(readOnly = true)
     public List<TurmaAlunoResponseDTO> listarAlunos(Long turmaId) {
-        return turmaAlunoDAO.findByTurmaIdOrderByAlunoNomeAsc(turmaId)
+        return turmaAlunoDAO.findByTurmaIdOrderByPacienteNomeAsc(turmaId)
                 .stream()
                 .map(TurmaAlunoResponseDTO::new)
                 .toList();
@@ -283,7 +283,7 @@ public class TurmaService {
         Aluno aluno = alunoDAO.findById(alunoId)
                 .orElseThrow(() -> new RuntimeException("Aluno não encontrado."));
 
-        TurmaAluno turmaAluno = turmaAlunoDAO.findByTurmaAndAluno(turma, aluno)
+        TurmaAluno turmaAluno = turmaAlunoDAO.findByTurmaAndPacienteId(turma, aluno)
                 .orElseThrow(() -> new RuntimeException("O aluno não pertence a esta turma."));
 
         if(ativo){
@@ -348,7 +348,7 @@ public class TurmaService {
     }
 
     private boolean isAlunoAtivoEmOutraTurma(Aluno aluno, Long turmaIdAtual) {
-        List<TurmaAluno> matriculasAtivas = turmaAlunoDAO.findAllByAlunoAndIsAlunoAtivoTrue(aluno);
+        List<TurmaAluno> matriculasAtivas = turmaAlunoDAO.findAllByPacienteIdAndAtivoTrue(aluno);
 
         return matriculasAtivas.stream()
                 .anyMatch(ta -> turmaIdAtual == null || !ta.getTurma().getId().equals(turmaIdAtual));


### PR DESCRIPTION
Close #377 

# O que mudou?

Agora as entidades `(Aulas, Avaliação, Presenca e Relatório)` foram refatoradas para o novo schema de `gestao_escolar` assim como os seus repositorys, contendo as PKs como UUID e removido qualquer relação direta com `aluno` e trocada para `paciente_id` .

**obs**: nos repositorys eu apenas **renomeei** elas para pegar os novos atributos `(ex: findByAulaAndAluno ficará findByAulaAndPacienteId)`, assim fica mais fácil reconhecer onde elas estavam sendo usadas para arrumar posteriormente.

## Tarefas Relacionadas

* Issue: https://github.com/IFPBEsp/APAE-gestao-escolar/issues/377
* Outras dependências: {pr_link}

## Mudanças Realizadas

* Refatoração da entidade e repository de  `Aula`
* Refatoração da entidade e repository de ` Avaliacao`
* Refatoração da entidade e repository de  `Presenca`
* Refatoração da entidade e repository de  `Relatorio`
* Refatoração do repository de `TurmaAluno`

## Evidências

<img width="1263" height="371" alt="image" src="https://github.com/user-attachments/assets/03bfae72-42b0-45f2-8869-0cbab41d052a" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Database objects moved under the gestao_escolar schema for clearer organization.
  * Primary keys migrated from numeric auto-increment to UUIDs across core entities.
  * Internal relations now reference pacienteId fields instead of entity references, affecting attendance, evaluations and reports lookups.
  * Class roster ordering and history queries now sort by paciente (patient) name.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->