### PR TITLE
[REFACTOR] Refatorar listagem de professores para eliminar N+1 Query Problem

### DIFF
--- a/api/src/main/java/com/apae/gestao/controller/ProfessorController.java
+++ b/api/src/main/java/com/apae/gestao/controller/ProfessorController.java
@@ -3,6 +3,7 @@ package com.apae.gestao.controller;
 import java.util.List;
 import java.util.UUID;
 
+import com.apae.gestao.dto.professor.ProfessorListagemDTO;
 import com.apae.gestao.dto.professor.ProfessorRequestDTO;
 import com.apae.gestao.dto.professor.ProfessorResponseDTO;
 import com.apae.gestao.dto.professor.ProfessorResumoDTO;
@@ -37,15 +38,12 @@ public class ProfessorController {
     @GetMapping
     @Operation(summary = "Listar professores")
     @ApiResponse(responseCode = "200", description = "Lista de professores retornada com sucesso")
-    public ResponseEntity<List<ProfessorResumoDTO>> listarTodos(
+    public ResponseEntity<List<ProfessorListagemDTO>> listarTodos(
             @Parameter(description = "ID do professor", in = ParameterIn.QUERY)
             @RequestParam(value = "id", required = false) UUID id,
 
             @Parameter(description = "Nome do professor para busca", example = "Maria", in = ParameterIn.QUERY)
             @RequestParam(value = "nome", required = false) String nome,
-
-            @Parameter(description = "CPF do professor", example = "12345678901", in = ParameterIn.QUERY)
-            @RequestParam(value = "cpf", required = false) String cpf,
 
             @Parameter(description = "Email do professor", example = "maria@escola.com", in = ParameterIn.QUERY)
             @RequestParam(value = "email", required = false) String email,
@@ -53,8 +51,8 @@ public class ProfessorController {
             @Parameter(description = "Filtrar por status ativo/inativo", example = "true", in = ParameterIn.QUERY)
             @RequestParam(value = "ativo", required = false) Boolean ativo) {
 
-        List<ProfessorResumoDTO> professores = professorService
-                .listarProfessores(id, nome, cpf, email, ativo);
+        List<ProfessorListagemDTO> professores = professorService
+                .listarProfessores(id, nome, email, ativo);
 
         return ResponseEntity.ok(professores);
     }

--- a/api/src/main/java/com/apae/gestao/dto/professor/ProfessorListagemDTO.java
+++ b/api/src/main/java/com/apae/gestao/dto/professor/ProfessorListagemDTO.java
@@ -5,7 +5,6 @@ import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
-import java.util.List;
 import java.util.UUID;
 
 @Data
@@ -16,6 +15,9 @@ public class ProfessorListagemDTO {
 
     @Schema(description = "Identificador único do professor")
     private UUID id;
+
+    @Schema(description = "Campo para saber se o professor está ativo", example = "false")
+    private Boolean ativo;
 
     @Schema(description = "Nome completo do professor", example = "Luan lorêto")
     private String nome;

--- a/api/src/main/java/com/apae/gestao/dto/professor/ProfessorListagemDTO.java
+++ b/api/src/main/java/com/apae/gestao/dto/professor/ProfessorListagemDTO.java
@@ -1,0 +1,29 @@
+package com.apae.gestao.dto.professor;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+import java.util.UUID;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Schema(description = "DTO otimizado para a tela de listagem de professores.")
+public class ProfessorListagemDTO {
+
+    @Schema(description = "Identificador único do professor")
+    private UUID id;
+
+    @Schema(description = "Nome completo do professor", example = "Luan lorêto")
+    private String nome;
+
+    @Schema(description = "E-mail do professor", example = "luan.loreto@gmail.com")
+    private String email;
+
+    @Schema(description = "Turmas vinculadas como responsável (separadas por vírgula)")
+    private String turmas;
+
+}

--- a/api/src/main/java/com/apae/gestao/entity/Turma.java
+++ b/api/src/main/java/com/apae/gestao/entity/Turma.java
@@ -33,6 +33,10 @@ public class Turma {
     @OneToMany(mappedBy = "turma", cascade = CascadeType.ALL, orphanRemoval = true)
     private Set<TurmaAluno> turmaAlunos = new HashSet<>();
 
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "professor_id")
+    private Professor professor;
+
 
     @OneToMany(mappedBy = "turma", cascade = CascadeType.ALL)
     private Set<Aula> aulas = new HashSet<>();

--- a/api/src/main/java/com/apae/gestao/entity/Usuario.java
+++ b/api/src/main/java/com/apae/gestao/entity/Usuario.java
@@ -44,7 +44,7 @@ public class Usuario {
     @Column(name = "endereco_id")
     private UUID enderecoId;
 
-    @Transient
+    @Column(name = "ativo", nullable = false)
     private Boolean ativo = true;
 
     @PrePersist

--- a/api/src/main/java/com/apae/gestao/repository/ProfessorRepository.java
+++ b/api/src/main/java/com/apae/gestao/repository/ProfessorRepository.java
@@ -1,9 +1,13 @@
 package com.apae.gestao.repository;
 
+import com.apae.gestao.dto.professor.ProfessorListagemDTO;
 import com.apae.gestao.entity.Professor;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -13,4 +17,20 @@ public interface ProfessorRepository extends JpaRepository<Professor, UUID> {
     Optional<Professor> findByUsuarioId(UUID usuarioId);
 
     boolean existsByUsuarioId(UUID usuarioId);
+
+    @Query(value = """
+        SELECT 
+            CAST(p.id AS VARCHAR) AS id,
+            u.nome_completo AS nome,
+            u.email AS email,
+            COALESCE(STRING_AGG(t.nome, ', '), 'Sem turma vinculada') AS turmas
+        FROM gestao_escolar.professores p
+        JOIN apae_geral.usuarios u ON p.usuario_id = u.id
+        LEFT JOIN gestao_escolar.turmas t ON t.professor_id = p.id
+        GROUP BY p.id, u.nome_completo, u.email
+    """, nativeQuery = true)
+    List<Object[]> listarProfessoresOtimizadoNativo(
+            @Param("nome") String nome,
+            @Param("email") String email
+    );
 }

--- a/api/src/main/java/com/apae/gestao/repository/ProfessorRepository.java
+++ b/api/src/main/java/com/apae/gestao/repository/ProfessorRepository.java
@@ -23,17 +23,19 @@ public interface ProfessorRepository extends JpaRepository<Professor, UUID> {
             u.ativo AS ativo,
             u.nome_completo AS nome,
             u.email AS email,
-            COALESCE(STRING_AGG(t.nome, ', '), 'Sem turma vinculada') AS turmas
+            COALESCE(STRING_AGG(t.nome, ', ' ORDER BY t.nome), 'Sem turma vinculada') AS turmas
         FROM gestao_escolar.professores p
         JOIN apae_geral.usuarios u ON p.usuario_id = u.id
         LEFT JOIN gestao_escolar.turmas t ON t.professor_id = p.id
         WHERE (:nome IS NULL OR TRIM(:nome) = '' OR LOWER(u.nome_completo) LIKE LOWER(CONCAT('%', TRIM(:nome), '%')))
           AND (:email IS NULL OR TRIM(:email) = '' OR LOWER(u.email) LIKE LOWER(CONCAT('%', TRIM(:email), '%')))
           AND (:ativo IS NULL OR u.ativo = :ativo)
+          AND (:id IS NULL OR p.id = :id)        
         GROUP BY p.id, u.ativo, u.nome_completo, u.email
         ORDER BY u.ativo DESC, u.nome_completo ASC
     """, nativeQuery = true)
     List<Object[]> listarProfessoresOtimizado(
+            @Param("id") UUID id,
             @Param("nome") String nome,
             @Param("email") String email,
             @Param("ativo") Boolean ativo

--- a/api/src/main/java/com/apae/gestao/repository/ProfessorRepository.java
+++ b/api/src/main/java/com/apae/gestao/repository/ProfessorRepository.java
@@ -1,6 +1,5 @@
 package com.apae.gestao.repository;
 
-import com.apae.gestao.dto.professor.ProfessorListagemDTO;
 import com.apae.gestao.entity.Professor;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -20,17 +19,23 @@ public interface ProfessorRepository extends JpaRepository<Professor, UUID> {
 
     @Query(value = """
         SELECT 
-            CAST(p.id AS VARCHAR) AS id,
+            p.id AS id,
+            u.ativo AS ativo,
             u.nome_completo AS nome,
             u.email AS email,
             COALESCE(STRING_AGG(t.nome, ', '), 'Sem turma vinculada') AS turmas
         FROM gestao_escolar.professores p
         JOIN apae_geral.usuarios u ON p.usuario_id = u.id
         LEFT JOIN gestao_escolar.turmas t ON t.professor_id = p.id
-        GROUP BY p.id, u.nome_completo, u.email
+        WHERE (:nome IS NULL OR TRIM(:nome) = '' OR LOWER(u.nome_completo) LIKE LOWER(CONCAT('%', TRIM(:nome), '%')))
+          AND (:email IS NULL OR TRIM(:email) = '' OR LOWER(u.email) LIKE LOWER(CONCAT('%', TRIM(:email), '%')))
+          AND (:ativo IS NULL OR u.ativo = :ativo)
+        GROUP BY p.id, u.ativo, u.nome_completo, u.email
+        ORDER BY u.ativo DESC, u.nome_completo ASC
     """, nativeQuery = true)
-    List<Object[]> listarProfessoresOtimizadoNativo(
+    List<Object[]> listarProfessoresOtimizado(
             @Param("nome") String nome,
-            @Param("email") String email
+            @Param("email") String email,
+            @Param("ativo") Boolean ativo
     );
 }

--- a/api/src/main/java/com/apae/gestao/service/ProfessorService.java
+++ b/api/src/main/java/com/apae/gestao/service/ProfessorService.java
@@ -1,9 +1,6 @@
 package com.apae.gestao.service;
 
-import com.apae.gestao.dto.professor.EnderecoDTO;
-import com.apae.gestao.dto.professor.ProfessorRequestDTO;
-import com.apae.gestao.dto.professor.ProfessorResponseDTO;
-import com.apae.gestao.dto.professor.ProfessorResumoDTO;
+import com.apae.gestao.dto.professor.*;
 import com.apae.gestao.entity.Endereco;
 import com.apae.gestao.entity.Professor;
 import com.apae.gestao.entity.Usuario;
@@ -43,20 +40,22 @@ public class ProfessorService {
     }
 
     @Transactional(readOnly = true)
-    public List<ProfessorResumoDTO> listarProfessores(UUID id, String nome, String cpf, String email, Boolean ativo) {
-        return professorRepository.findAll()
-                .stream()
-                .filter(professor -> id == null || id.equals(professor.getId()))
-                .map(professor -> {
-                    Usuario usuario = buscarUsuario(professor);
-                    return new ProfessorUsuario(professor, usuario, buscarEndereco(usuario));
-                })
-                .filter(item -> nome == null || item.usuario().getNomeCompleto().toLowerCase().contains(nome.toLowerCase()))
-                .filter(item -> cpf == null || cpf.equals(item.usuario().getCpf()))
-                .filter(item -> email == null || email.equalsIgnoreCase(item.usuario().getEmail()))
-                .filter(item -> ativo == null || ativo.equals(item.usuario().getAtivo()))
-                .map(item -> toResumo(item.professor(), item.usuario(), item.endereco()))
-                .toList();
+    public List<ProfessorListagemDTO> listarProfessores(UUID id, String nome, String email, Boolean ativo) {
+
+        List<Object[]> resultados = professorRepository.listarProfessoresOtimizadoNativo(nome, email);
+
+        List<ProfessorListagemDTO> lista = resultados.stream().map(row -> new ProfessorListagemDTO(
+                UUID.fromString((String) row[0]),
+                (String) row[1],
+                (String) row[2],
+                (String) row[3]
+        )).toList();
+
+        if (id != null) {
+            return lista.stream().filter(p -> p.getId().equals(id)).toList();
+        }
+
+        return lista;
     }
 
     @Transactional(readOnly = true)

--- a/api/src/main/java/com/apae/gestao/service/ProfessorService.java
+++ b/api/src/main/java/com/apae/gestao/service/ProfessorService.java
@@ -42,7 +42,7 @@ public class ProfessorService {
     @Transactional(readOnly = true)
     public List<ProfessorListagemDTO> listarProfessores(UUID id, String nome, String email, Boolean ativo) {
 
-        List<Object[]> resultados = professorRepository.listarProfessoresOtimizado(nome, email, ativo);
+        List<Object[]> resultados = professorRepository.listarProfessoresOtimizado(id, nome, email, ativo);
 
         List<ProfessorListagemDTO> lista = resultados.stream().map(row -> new ProfessorListagemDTO(
                 (UUID) row[0],
@@ -51,10 +51,6 @@ public class ProfessorService {
                 (String) row[3], //email
                 (String) row[4] //turmas
         )).toList();
-
-        if (id != null) {
-            return lista.stream().filter(p -> p.getId().equals(id)).toList();
-        }
 
         return lista;
     }

--- a/api/src/main/java/com/apae/gestao/service/ProfessorService.java
+++ b/api/src/main/java/com/apae/gestao/service/ProfessorService.java
@@ -42,13 +42,14 @@ public class ProfessorService {
     @Transactional(readOnly = true)
     public List<ProfessorListagemDTO> listarProfessores(UUID id, String nome, String email, Boolean ativo) {
 
-        List<Object[]> resultados = professorRepository.listarProfessoresOtimizadoNativo(nome, email);
+        List<Object[]> resultados = professorRepository.listarProfessoresOtimizado(nome, email, ativo);
 
         List<ProfessorListagemDTO> lista = resultados.stream().map(row -> new ProfessorListagemDTO(
-                UUID.fromString((String) row[0]),
-                (String) row[1],
-                (String) row[2],
-                (String) row[3]
+                (UUID) row[0],
+                (Boolean) row[1], //ativo
+                (String) row[2], //nome
+                (String) row[3], //email
+                (String) row[4] //turmas
         )).toList();
 
         if (id != null) {

--- a/api/src/main/resources/db/migration/V6__add_professor_id_to_turmas.sql
+++ b/api/src/main/resources/db/migration/V6__add_professor_id_to_turmas.sql
@@ -1,0 +1,10 @@
+ALTER TABLE gestao_escolar.turmas
+    ADD COLUMN IF NOT EXISTS professor_id UUID;
+
+ALTER TABLE gestao_escolar.turmas
+    ADD CONSTRAINT fk_turma_professor
+    FOREIGN KEY (professor_id)
+    REFERENCES gestao_escolar.professores(id);
+
+CREATE INDEX IF NOT EXISTS idx_turmas_professor
+    ON gestao_escolar.turmas(professor_id);

--- a/app/src/app/admin/professores/page.jsx
+++ b/app/src/app/admin/professores/page.jsx
@@ -90,10 +90,7 @@ export default function Professores() {
             </p>
           </div>
 
-          <Button
-            variant="primary"
-            onClick={() => router.push("/admin/professores/cadastrar")}
-          >
+          <Button variant="primary" onClick={() => router.push('/admin/professores/cadastrar')}>
             <UserPlus className="mr-2 h-5 w-5" />
             Cadastrar Professor
           </Button>
@@ -123,7 +120,7 @@ export default function Professores() {
           <div className="flex flex-col items-center justify-center py-12 space-y-2">
             {!error && (
               <p className="text-[#222222] text-base md:text-lg font-medium text-center px-4">
-                {searchTerm ? "Nenhum professor encontrado." : "Nenhum professor cadastrado."}
+                {searchTerm ? 'Nenhum professor encontrado.' : 'Nenhum professor cadastrado.'}
               </p>
             )}
             {error && (
@@ -150,18 +147,25 @@ export default function Professores() {
                       <h3 className="text-base md:text-lg font-semibold text-[#0D4F97] mb-1 truncate">
                         {professor.nome}
                       </h3>
-                      <span className={`inline-block rounded-full px-2 md:px-3 py-1 text-xs md:text-sm font-medium ${professor.ativo
-                          ? "bg-green-100 text-green-700"
-                          : "bg-red-100 text-red-700"
-                        }`}>
-                        {professor.ativo ? "Ativo" : "Inativo"}
+                      <span
+                        className={`inline-block rounded-full px-2 md:px-3 py-1 text-xs md:text-sm font-medium ${
+                          professor.ativo
+                            ? 'bg-green-100 text-green-700'
+                            : 'bg-red-100 text-red-700'
+                        }`}
+                      >
+                        {professor.ativo ? 'Ativo' : 'Inativo'}
                       </span>
                     </div>
                   </div>
 
                   <div className="mt-3 md:mt-4 text-xs md:text-sm text-[#222222] space-y-1">
                     <p className="truncate">{professor.email}</p>
-                    {professor.formacao && <p className="truncate">{professor.formacao}</p>}
+                    {professor.turmas && (
+                      <p className="truncate text-[#0D4F97] font-medium mt-1">
+                        Turmas: {professor.turmas}
+                      </p>
+                    )}
                   </div>
                 </CardContent>
               </Card>


### PR DESCRIPTION
Close #380 

# O que mudou?

Agora a listagem de professores em `admin/professores ` não possui mais o n+1 query problem, sendo puxado apenas as informações necessárias para a tela (nome,email,ativo e nome das turmas)

## Tarefas Relacionadas

* Issue: https://github.com/IFPBEsp/APAE-gestao-escolar/issues/380
* Outras dependências: 

## Mudanças Realizadas

* Criado o DTO para listagem específica da tela
* Mudança no service de listagem para usar o dto
* Criação da query em `professorRepository` para melhor consulta
* Edição do card de professores para aparecer o nome das turmas

## Evidências

<img width="1391" height="734" alt="image" src="https://github.com/user-attachments/assets/1b8d2f58-db8c-44e6-b670-ad76629916aa" />

<img width="1356" height="750" alt="image" src="https://github.com/user-attachments/assets/fe0965cd-4974-4c11-b19a-02519807eaf0" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Professor listings now display assigned classes (turmas) for each professor.

* **Refactor**
  * Optimized professor listing queries for improved database performance.
  * Removed CPF as a filterable parameter from professor search functionality.
  * Established explicit relationships between professors and their assigned classes in the data model.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->